### PR TITLE
Convert parse.pas from string quanta to pstring

### DIFF
--- a/source/parse.pas
+++ b/source/parse.pas
@@ -102,8 +102,7 @@ program parse(output,command);
 
 joins services; { system services }
 
-uses endian,   { endian mode }
-     strings,  { string handling }
+uses strings,  { string handling }
      mpb,      { machine parameter block }
      version,  { current version number }
      parcmd;   { command line parsing }


### PR DESCRIPTION
## Summary

- Replace legacy string quanta system (linked lists of 10-char blocks) with Pascaline's native `pstring` type
- Join the `strings` module and use its functions for string operations
- Remove ~100 lines of obsolete code while improving memory efficiency

## Changes

- Remove `varsqt`, `strvsp`, `strvs` type definitions and `strcnt` tracking variable
- Change all `strvsp` fields to `pstring` in `identifier`, `filrec`, `labl`, `constant`, and `disprec` records
- Add helper functions for pstring operations with nil-safety and proper padded string comparison
- Use `strings.copy`, `strings.cat`, `strings.len`, `strings.comp`, `strings.gtr`, `strings.clears` functions
- Remove 16 obsolete string quanta functions
- Initialize pstring fields to nil after `new()` to prevent disposing garbage pointers

## Test plan

- [x] Compiles without errors
- [x] `parse sample_programs/hello.pas` - passes (0 errors)
- [x] `parse standard_tests/iso7185pat.pas` - passes (0 errors)

🤖 Generated with [Claude Code](https://claude.ai/code)