### PR TITLE
Fix container length mismatch in schjmp label comparison

### DIFF
--- a/source/pgen/independent.pas
+++ b/source/pgen/independent.pas
@@ -996,6 +996,19 @@ begin
   end
 end;
 
+{ compare strings using padded length (ignores container size differences) }
+function streqp(view a, b: string): boolean;
+var i, la, lb: integer; r: boolean;
+begin
+  la := lenp(a); lb := lenp(b);
+  if la <> lb then r := false
+  else begin
+    r := true;
+    for i := 1 to la do if a[i] <> b[i] then r := false
+  end;
+  streqp := r
+end;
+
 { make string from string substring }
 function strl(view s: string; l: integer): pstring;
 var p: pstring; i: integer;
@@ -1179,7 +1192,7 @@ var ep, lp, fp: expptr;
 begin
   ep := jmpstr; lp := nil; fp := nil;
   while ep <> nil do begin
-    if ep^.qs^ = s then begin fp := ep; ep := nil end
+    if streqp(ep^.qs^, s) then begin fp := ep; ep := nil end
     else begin lp := ep; ep := ep^.next end
   end;
   if fp <> nil then if fp^.l <> nil then begin


### PR DESCRIPTION
## Summary

- Add `streqp` function to compare strings by padded length (content) rather than container size
- Fix crash in pgen when processing case statements with non-consecutive enumeration labels inside loops

## Root Cause

Label strings stored in the jump cache had varying container sizes depending on how they were created via `strp()`. When `schjmp` searched for a label, the direct `=` comparison failed because Pascaline container comparison requires identical container lengths, not just identical content.

## Solution

Added a `streqp` function that uses `lenp()` to get the content length (excluding trailing spaces) and compares strings character-by-character. This allows comparison of strings with the same content regardless of their container sizes.

## Test plan

- [x] Regression tests pass (100%)
- [x] Minimum reproducer (`utils/pasfmt_min.pas`) compiles successfully
- [x] Full pasfmt.pas formatter compiles successfully

Fixes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)