### PR TITLE
Refactor pasfmt to use parse module for command line processing

### DIFF
--- a/utils/pasfmt.pas
+++ b/utils/pasfmt.pas
@@ -170,6 +170,7 @@ var
     { file names }
     srcfil:   filnam;            { source filename }
     dstfil:   filnam;            { destination filename }
+    p, n, e:  filnam;            { path, name, extension components }
 
     { symbol sets for error recovery }
     constbegsys, simptypebegsys, typebegsys, blockbegsys,
@@ -1823,43 +1824,15 @@ begin
         goto 99
     end;
     paropt; { parse any trailing options }
-    { strip extension if present, keep base name in srcfil }
-    i := 1;
-    while (i < fillen) and (srcfil[i] <> ' ') and (srcfil[i] <> '.') do i := i + 1;
-    if srcfil[i] = '.' then begin
-        { has extension, remove it from srcfil (keep base name only) }
-        while (i <= fillen) and (srcfil[i] <> ' ') do begin
-            srcfil[i] := ' ';
-            i := i + 1
-        end
-    end;
-    { create input filename: srcfil + .pas }
-    for i := 1 to fillen do dstfil[i] := srcfil[i]; { use dstfil temporarily }
-    i := 1;
-    while (i < fillen) and (dstfil[i] <> ' ') do i := i + 1;
-    if i + 4 <= fillen then begin
-        dstfil[i] := '.';
-        dstfil[i+1] := 'p';
-        dstfil[i+2] := 'a';
-        dstfil[i+3] := 's'
-    end;
-    assign(prd, dstfil);
+    { break filename into path, name, extension }
+    services.brknam(srcfil, p, n, e);
+    { create input filename: path + name + .pas }
+    services.maknam(srcfil, p, n, 'pas');
+    assign(prd, srcfil);
     reset(prd);
-
-    { create output filename: srcfil + .pas.fmt }
-    for i := 1 to fillen do dstfil[i] := srcfil[i];
-    i := 1;
-    while (i < fillen) and (dstfil[i] <> ' ') do i := i + 1;
-    if i + 8 <= fillen then begin
-        dstfil[i] := '.';
-        dstfil[i+1] := 'p';
-        dstfil[i+2] := 'a';
-        dstfil[i+3] := 's';
-        dstfil[i+4] := '.';
-        dstfil[i+5] := 'f';
-        dstfil[i+6] := 'm';
-        dstfil[i+7] := 't'
-    end;
+    { create output filename: path + name + .pas.fmt }
+    services.maknam(dstfil, p, n, 'pas');
+    cat(dstfil, '.fmt');
     assign(prr, dstfil);
     rewrite(prr)
 end;


### PR DESCRIPTION
## Summary
- Refactors `utils/pasfmt.pas` to use the `parse` module for command line handling instead of `parcmd`
- Follows the same pattern as `pc.pas` for cleaner, more consistent option parsing
- Adds `-e`/`--experr` option to control expanded error message display

## Changes
- Replace `uses parcmd` with `joins parse, services` and `uses strings`
- Renamed `list` variable to `listmode` (avoids conflict with `services.list`)
- Removed local `lcase` function (uses `strings.lcase` instead)
- Added `paropt` procedure for option parsing with negation support
- Output filename now uses `.pas.fmt` extension

## Options
- `-l` / `--list` - List source lines while processing
- `-s` / `--iso7185` - Format as ISO 7185 Pascal (not Pascaline)
- `-e` / `--experr` - Show expanded error messages (default on)
- Negation with `n` prefix: `-ne`, `--nexperr`, etc.

## Test plan
- [x] `./utils/pasfmt sample_programs/hello.pas` - basic formatting works
- [x] `./utils/pasfmt -l sample_programs/hello.pas` - list mode works
- [x] `./utils/pasfmt -s tex.pas` - ISO 7185 mode processes all 6028 lines
- [x] `./utils/pasfmt --list --iso7185 sample_programs/hello` - long options work
- [x] `./utils/pasfmt -ne sample_programs/hello.pas` - negation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)