### PR TITLE
Add formatting options and instruction file support to pasfmt

### DIFF
--- a/utils/pasfmt.pas
+++ b/utils/pasfmt.pas
@@ -2,32 +2,6 @@
 *                                                                              *
 *                         PASCALINE SOURCE FORMATTER                           *
 *                                                                              *
-* LICENSING:                                                                   *
-*                                                                              *
-* Copyright (c) 2024, Scott A. Franco                                          *
-* All rights reserved.                                                         *
-*                                                                              *
-* Redistribution and use in source and binary forms, with or without           *
-* modification, are permitted provided that the following conditions are met:  *
-*                                                                              *
-* 1. Redistributions of source code must retain the above copyright notice,    *
-*    this list of conditions and the following disclaimer.                     *
-* 2. Redistributions in binary form must reproduce the above copyright         *
-*    notice, this list of conditions and the following disclaimer in the       *
-*    documentation and/or other materials provided with the distribution.      *
-*                                                                              *
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"  *
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE    *
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE   *
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE     *
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR          *
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF         *
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS     *
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN      *
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)      *
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE   *
-* POSSIBILITY OF SUCH DAMAGE.                                                  *
-*                                                                              *
 *                     Pascaline Source Code Formatter                          *
 *                     *******************************                          *
 *                                                                              *
@@ -71,6 +45,32 @@
 *                                                                              *
 * Comments start with '!' and continue to end of line. They can appear at the  *
 * start of a line or after commands.                                           *
+*                                                                              *
+* LICENSING:                                                                   *
+*                                                                              *
+* Copyright (c) 2024, Scott A. Franco                                          *
+* All rights reserved.                                                         *
+*                                                                              *
+* Redistribution and use in source and binary forms, with or without           *
+* modification, are permitted provided that the following conditions are met:  *
+*                                                                              *
+* 1. Redistributions of source code must retain the above copyright notice,    *
+*    this list of conditions and the following disclaimer.                     *
+* 2. Redistributions in binary form must reproduce the above copyright         *
+*    notice, this list of conditions and the following disclaimer in the       *
+*    documentation and/or other materials provided with the distribution.      *
+*                                                                              *
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"  *
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE    *
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE   *
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE     *
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR          *
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF         *
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS     *
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN      *
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)      *
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE   *
+* POSSIBILITY OF SUCH DAMAGE.                                                  *
 *                                                                              *
 *******************************************************************************}
 


### PR DESCRIPTION
## Summary

- Add comprehensive command line options for controlling formatting behavior
- Add instruction file support (reads `<inputfile>.fmt` for options)
- Add column wrapping at configurable width (default 80)
- Add source line number tracking in output
- Add error suppression option (`--noerror`)
- Change output filename from `.fmt` to `.pas.fmt` to avoid instruction file conflicts

## New Options

| Option | Description |
|--------|-------------|
| `-l, --list` | List source lines while processing |
| `-s, --iso7185` | Format as ISO 7185 Pascal |
| `-e, --experr` | Show expanded error messages (default: on) |
| `-c, --columns <n>` | Set wrap column (default: 80) |
| `-b, --bracketbreak` | Add blank lines around begin/end, etc. |
| `-f, --flushleft` | Flush left for const/type/var blocks |
| `-z, --columnize` | Align = signs (placeholder) |
| `-n, --sourceline` | Add source line numbers as comments |
| `-r, --noerror` | Suppress error output (keep error count) |

## Test plan

- [ ] Run `pasfmt --help` to verify options are listed
- [ ] Test formatting with various option combinations
- [ ] Test instruction file parsing
- [ ] Verify column wrapping works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)