### PR TITLE
Add procedure/function support to p2c translator

### DIFF
--- a/utils/p2c.pas
+++ b/utils/p2c.pas
@@ -1533,31 +1533,32 @@ begin
   else if fsp = charptr then c_str('char')
   else if fsp = boolptr then c_str('int')
   else if fsp = byteptr then c_str('unsigned char')
-  else if fsp^.form = subrange then begin
-    { use appropriate integer type based on range }
-    if fsp^.rangetype = charptr then c_str('char')
-    else if (fsp^.min.ival >= 0) and (fsp^.max.ival <= 255) then
-      c_str('unsigned char')
-    else if (fsp^.min.ival >= -128) and (fsp^.max.ival <= 127) then
-      c_str('signed char')
-    else if (fsp^.min.ival >= 0) and (fsp^.max.ival <= 65535) then
-      c_str('unsigned short')
-    else if (fsp^.min.ival >= -32768) and (fsp^.max.ival <= 32767) then
-      c_str('short')
-    else
-      c_str('long')
+  else case fsp^.form of
+    subrange: begin
+      { use appropriate integer type based on range }
+      if fsp^.rangetype = charptr then c_str('char')
+      else if (fsp^.min.ival >= 0) and (fsp^.max.ival <= 255) then
+        c_str('unsigned char')
+      else if (fsp^.min.ival >= -128) and (fsp^.max.ival <= 127) then
+        c_str('signed char')
+      else if (fsp^.min.ival >= 0) and (fsp^.max.ival <= 65535) then
+        c_str('unsigned short')
+      else if (fsp^.min.ival >= -32768) and (fsp^.max.ival <= 32767) then
+        c_str('short')
+      else
+        c_str('long')
+    end;
+    pointer: begin
+      c_basetype(fsp^.eltype);
+      c_chr('*')
+    end;
+    scalar:  c_str('int');  { enumerated types map to int }
+    power:   c_str('unsigned char');  { sets are byte arrays }
+    arrays:  c_basetype(fsp^.aeltype);
+    arrayc:  c_basetype(fsp^.abstype);
+    records: c_str('struct');  { need name }
+    files:   c_str('FILE*')
   end
-  else if fsp^.form = pointer then begin
-    c_basetype(fsp^.eltype);
-    c_chr('*')
-  end
-  else if fsp^.form = scalar then c_str('int')  { enumerated types map to int }
-  else if fsp^.form = power then c_str('unsigned char')  { sets are byte arrays }
-  else if fsp^.form = arrays then c_basetype(fsp^.aeltype)
-  else if fsp^.form = arrayc then c_basetype(fsp^.abstype)
-  else if fsp^.form = records then c_str('struct')  { need name }
-  else if fsp^.form = files then c_str('FILE*')
-  else c_str('/* unknown type */')
 end;
 
 procedure c_type(fsp: stp);


### PR DESCRIPTION
## Summary
- Add procedure and function body output with proper C formatting
- Output global variables at C file scope before function definitions
- Translate string assignments to strcpy() calls
- Fix writeln/write standard procedure output
- Add enum type translation (maps to int)
- Add string.h include for strcpy support

## Test Results
4 of 10 sample programs now compile:
- ✓ hello
- ✓ prime  
- ✓ roman
- ✓ qsort

## Known Limitations
- Record/struct types need type names
- Standard functions (eoln, eof) not yet translated
- 1-based array indexing not adjusted for C

🤖 Generated with [Claude Code](https://claude.com/claude-code)