### PR TITLE
Fix p2c alias handling and add nested procedure support

### DIFF
--- a/utils/p2c.pas
+++ b/utils/p2c.pas
@@ -3211,7 +3211,9 @@ end;
       if (disx <> top) and (display[top].define) and not pdf then begin
         { downlevel, create an alias and link to bottom }
         new(lcp1, alias); ininam(lcp1); lcp1^.klass := alias;
-        lcp1^.name := lcp^.name; lcp1^.actid := lcp;
+        strcopy(lcp1^.name, lcp^.name^); { copy name string }
+        lcp1^.actid := lcp;
+        lcp^.keep := true; { prevent disposal while alias references it }
         enterid(lcp1)
       end
     end else begin (*search not successful


### PR DESCRIPTION
## Summary
- Fix dangling pointer crash in alias handling when translating large programs with deeply nested procedures
- Copy alias name string instead of sharing pointer
- Set keep flag on referenced identifiers to prevent premature disposal
- Previous commits in branch add nested procedure support and case statement translation

## Details
When p2c creates an alias for a downlevel identifier reference, it now:
1. Copies the name string so the alias has its own valid copy
2. Sets `keep=true` on the actual identifier to prevent disposal while aliases reference it

This fixes segfaults when translating programs like basic/basic.pas (7942 lines) which has deeply nested procedures.

## Test plan
- [x] basic/basic.pas (7942 lines) translates successfully without crashing
- [x] Generated C code is 9789 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)