### PR TITLE
Add DAP debug adapter for VS Code

### DIFF
--- a/vscode-pascaline/.vscodeignore
+++ b/vscode-pascaline/.vscodeignore
@@ -1,0 +1,6 @@
+src/**
+node_modules/**
+tsconfig.json
+.gitignore
+**/*.ts
+**/*.map

--- a/vscode-pascaline/package.json
+++ b/vscode-pascaline/package.json
@@ -1,8 +1,8 @@
 {
   "name": "pascaline",
   "displayName": "Pascaline",
-  "description": "Language support for the Pascaline programming language (ISO 7185 Pascal extended)",
-  "version": "0.1.0",
+  "description": "Language support and debugging for the Pascaline programming language (ISO 7185 Pascal extended)",
+  "version": "0.2.0",
   "publisher": "pascal-p6",
   "repository": {
     "type": "git",
@@ -12,7 +12,13 @@
     "vscode": "^1.75.0"
   },
   "categories": [
-    "Programming Languages"
+    "Programming Languages",
+    "Debuggers"
+  ],
+  "main": "./out/extension.js",
+  "activationEvents": [
+    "onDebugResolve:pascaline",
+    "onDebugDynamicConfigurations:pascaline"
   ],
   "contributes": {
     "languages": [
@@ -35,6 +41,82 @@
         "scopeName": "source.pascaline",
         "path": "./syntaxes/pascaline.tmLanguage.json"
       }
+    ],
+    "breakpoints": [
+      {
+        "language": "pascaline"
+      }
+    ],
+    "debuggers": [
+      {
+        "type": "pascaline",
+        "label": "Pascaline Debug",
+        "languages": [
+          "pascaline"
+        ],
+        "configurationAttributes": {
+          "launch": {
+            "required": [
+              "program"
+            ],
+            "properties": {
+              "program": {
+                "type": "string",
+                "description": "Absolute path to the .pas source file to debug."
+              },
+              "pc": {
+                "type": "string",
+                "description": "Path to the pc compiler. Defaults to 'pc' on PATH.",
+                "default": "pc"
+              },
+              "pint": {
+                "type": "string",
+                "description": "Path to the pint interpreter. Defaults to 'pint' on PATH.",
+                "default": "pint"
+              },
+              "stopOnEntry": {
+                "type": "boolean",
+                "description": "Stop at the first statement of the program.",
+                "default": true
+              }
+            }
+          }
+        },
+        "initialConfigurations": [
+          {
+            "type": "pascaline",
+            "request": "launch",
+            "name": "Debug Pascal Program",
+            "program": "${file}",
+            "stopOnEntry": true
+          }
+        ],
+        "configurationSnippets": [
+          {
+            "label": "Pascaline: Debug Program",
+            "description": "Debug a Pascaline/Pascal program using pint",
+            "body": {
+              "type": "pascaline",
+              "request": "launch",
+              "name": "Debug ${1:program}",
+              "program": "^\"\\${file}\"",
+              "stopOnEntry": true
+            }
+          }
+        ]
+      }
     ]
+  },
+  "scripts": {
+    "build": "tsc -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "devDependencies": {
+    "@types/node": "^18.0.0",
+    "@types/vscode": "^1.75.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "@vscode/debugadapter": "^1.65.0"
   }
 }

--- a/vscode-pascaline/src/extension.ts
+++ b/vscode-pascaline/src/extension.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode';
+import { PascalineDebugSession } from './pascalineDebug';
+
+export function activate(context: vscode.ExtensionContext) {
+    const factory = new InlineDebugAdapterFactory();
+    context.subscriptions.push(
+        vscode.debug.registerDebugAdapterDescriptorFactory('pascaline', factory)
+    );
+}
+
+export function deactivate() {
+    // nothing to clean up
+}
+
+class InlineDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory {
+    createDebugAdapterDescriptor(
+        _session: vscode.DebugSession
+    ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+        return new vscode.DebugAdapterInlineImplementation(
+            new PascalineDebugSession() as any
+        );
+    }
+}

--- a/vscode-pascaline/src/pascalineDebug.ts
+++ b/vscode-pascaline/src/pascalineDebug.ts
@@ -1,0 +1,567 @@
+import {
+    LoggingDebugSession,
+    InitializedEvent,
+    StoppedEvent,
+    TerminatedEvent,
+    OutputEvent,
+    Thread,
+    StackFrame,
+    Scope,
+    Source,
+    Variable
+} from '@vscode/debugadapter';
+import { DebugProtocol } from '@vscode/debugprotocol';
+import { PintRunner, StoppedInfo } from './pintRunner';
+import { execFile } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+
+const THREAD_ID = 1;
+
+interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
+    program: string;
+    pc?: string;
+    pint?: string;
+    stopOnEntry?: boolean;
+}
+
+/**
+ * Pascaline debug session implementing the Debug Adapter Protocol.
+ * Translates DAP requests into pint debugger commands and parses responses.
+ */
+export class PascalineDebugSession extends LoggingDebugSession {
+    private pintRunner: PintRunner | null = null;
+    private sourceFile: string = '';
+    private sourceDir: string = '';
+    private programName: string = '';
+
+    /** Breakpoints keyed by source file path. */
+    private breakpointsByFile: Map<string, DebugProtocol.SourceBreakpoint[]> = new Map();
+
+    /** Next breakpoint ID for DAP. */
+    private breakpointId = 1;
+
+    /** Whether the program has been launched and initial setup is complete. */
+    private configDone = false;
+
+    /** Pending configurationDone resolve. */
+    private configDoneResolve: (() => void) | null = null;
+
+    constructor() {
+        super();
+        this.setDebuggerLinesStartAt1(true);
+        this.setDebuggerColumnsStartAt1(true);
+    }
+
+    /**
+     * DAP: Initialize - return capabilities.
+     */
+    protected initializeRequest(
+        response: DebugProtocol.InitializeResponse,
+        _args: DebugProtocol.InitializeRequestArguments
+    ): void {
+        response.body = response.body || {};
+        response.body.supportsConfigurationDoneRequest = true;
+        response.body.supportsEvaluateForHovers = true;
+        response.body.supportsStepBack = false;
+        response.body.supportsSetVariable = true;
+        response.body.supportsFunctionBreakpoints = false;
+        response.body.supportsConditionalBreakpoints = false;
+        response.body.supportsHitConditionalBreakpoints = false;
+        response.body.supportsLogPoints = false;
+        response.body.supportsTerminateRequest = true;
+
+        this.sendResponse(response);
+        this.sendEvent(new InitializedEvent());
+    }
+
+    /**
+     * DAP: ConfigurationDone - breakpoints have been set, we can proceed.
+     */
+    protected configurationDoneRequest(
+        response: DebugProtocol.ConfigurationDoneResponse,
+        _args: DebugProtocol.ConfigurationDoneArguments
+    ): void {
+        this.configDone = true;
+        if (this.configDoneResolve) {
+            this.configDoneResolve();
+        }
+        this.sendResponse(response);
+    }
+
+    /**
+     * Wait for configurationDone if it hasn't happened yet.
+     */
+    private waitForConfigDone(): Promise<void> {
+        if (this.configDone) return Promise.resolve();
+        return new Promise(resolve => {
+            this.configDoneResolve = resolve;
+        });
+    }
+
+    /**
+     * DAP: Launch - compile the program and start pint in debug mode.
+     */
+    protected async launchRequest(
+        response: DebugProtocol.LaunchResponse,
+        args: LaunchRequestArguments
+    ): Promise<void> {
+        const programPath = args.program;
+        const pcPath = args.pc || 'pc';
+        const pintPath = args.pint || 'pint';
+        const stopOnEntry = args.stopOnEntry !== false;
+
+        // Validate source file exists
+        if (!fs.existsSync(programPath)) {
+            this.sendErrorResponse(response, 1, `Source file not found: ${programPath}`);
+            return;
+        }
+
+        this.sourceFile = path.resolve(programPath);
+        this.sourceDir = path.dirname(this.sourceFile);
+        // Strip .pas extension for the program name
+        this.programName = path.basename(this.sourceFile, '.pas');
+
+        // Step 1: Compile with pc
+        this.sendEvent(new OutputEvent(`Compiling ${this.programName}...\n`, 'console'));
+
+        try {
+            await this.compile(pcPath, this.programName, this.sourceDir);
+        } catch (err: any) {
+            this.sendEvent(new OutputEvent(`Compilation failed: ${err.message}\n`, 'stderr'));
+            this.sendErrorResponse(response, 2, `Compilation failed: ${err.message}`);
+            return;
+        }
+
+        this.sendEvent(new OutputEvent(`Compilation successful.\n`, 'console'));
+
+        // Step 2: Start pint in debug mode
+        const p6File = path.join(this.sourceDir, this.programName + '.p6');
+        const outFile = path.join(this.sourceDir, this.programName + '.out');
+
+        this.pintRunner = new PintRunner();
+
+        // Wire up events
+        this.pintRunner.on('output', (text: string) => {
+            this.sendEvent(new OutputEvent(text, 'stdout'));
+        });
+
+        this.pintRunner.on('stderr', (text: string) => {
+            this.sendEvent(new OutputEvent(text, 'stderr'));
+        });
+
+        this.pintRunner.on('exited', (_code: number) => {
+            this.sendEvent(new TerminatedEvent());
+        });
+
+        this.pintRunner.on('stopped', (info: StoppedInfo) => {
+            this.sendEvent(new StoppedEvent(info.reason, THREAD_ID));
+        });
+
+        try {
+            const startOutput = await this.pintRunner.start(pintPath, p6File, outFile);
+
+            // Parse initial source context to find the entry point line
+            const sourceLines = this.pintRunner.parseSourceLines(startOutput);
+            const currentLine = sourceLines.find(l => l.isCurrent);
+
+            this.sendResponse(response);
+
+            // Wait for breakpoints to be configured
+            await this.waitForConfigDone();
+
+            // Set any pending breakpoints
+            await this.syncBreakpoints();
+
+            if (stopOnEntry && currentLine) {
+                // Already stopped at entry point
+                this.sendEvent(new StoppedEvent('entry', THREAD_ID));
+            } else if (!stopOnEntry) {
+                // Run to first breakpoint or completion
+                this.continueExecution();
+            } else {
+                this.sendEvent(new StoppedEvent('entry', THREAD_ID));
+            }
+        } catch (err: any) {
+            this.sendEvent(new OutputEvent(`Failed to start pint: ${err.message}\n`, 'stderr'));
+            this.sendErrorResponse(response, 3, `Failed to start pint: ${err.message}`);
+        }
+    }
+
+    /**
+     * Compile the Pascal program using pc.
+     */
+    private compile(pcPath: string, programName: string, cwd: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            execFile(pcPath, [programName, '--debugsrc', '-r'], { cwd }, (error, stdout, stderr) => {
+                if (stdout) {
+                    this.sendEvent(new OutputEvent(stdout, 'console'));
+                }
+                if (stderr) {
+                    this.sendEvent(new OutputEvent(stderr, 'stderr'));
+                }
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve();
+                }
+            });
+        });
+    }
+
+    /**
+     * DAP: SetBreakpoints - set breakpoints for a source file.
+     */
+    protected async setBreakpointsRequest(
+        response: DebugProtocol.SetBreakpointsResponse,
+        args: DebugProtocol.SetBreakpointsArguments
+    ): Promise<void> {
+        const sourcePath = args.source.path || '';
+        const requestedBps = args.breakpoints || [];
+
+        // Store breakpoints for this file
+        this.breakpointsByFile.set(sourcePath, requestedBps);
+
+        // If pint is running, sync breakpoints now
+        if (this.pintRunner && this.configDone) {
+            await this.syncBreakpoints();
+        }
+
+        // Return all breakpoints as verified (pint will validate on set)
+        const breakpoints: DebugProtocol.Breakpoint[] = requestedBps.map(bp => {
+            return {
+                id: this.breakpointId++,
+                verified: true,
+                line: bp.line
+            };
+        });
+
+        response.body = { breakpoints };
+        this.sendResponse(response);
+    }
+
+    /**
+     * Sync all breakpoints to pint: clear all, then set each one.
+     */
+    private async syncBreakpoints(): Promise<void> {
+        if (!this.pintRunner) return;
+
+        // Clear all breakpoints in pint
+        await this.pintRunner.sendCommand('c');
+
+        // Set breakpoints for each file
+        for (const [filePath, bps] of this.breakpointsByFile) {
+            // Determine module name from file path
+            const moduleName = path.basename(filePath, '.pas');
+
+            for (const bp of bps) {
+                await this.pintRunner.sendCommand(`b ${moduleName} ${bp.line}`);
+            }
+        }
+    }
+
+    /**
+     * DAP: Threads - pint is single-threaded, always return one thread.
+     */
+    protected threadsRequest(response: DebugProtocol.ThreadsResponse): void {
+        response.body = {
+            threads: [new Thread(THREAD_ID, 'main')]
+        };
+        this.sendResponse(response);
+    }
+
+    /**
+     * DAP: StackTrace - get the call stack using pint's "df" command.
+     */
+    protected async stackTraceRequest(
+        response: DebugProtocol.StackTraceResponse,
+        _args: DebugProtocol.StackTraceArguments
+    ): Promise<void> {
+        if (!this.pintRunner) {
+            response.body = { stackFrames: [], totalFrames: 0 };
+            this.sendResponse(response);
+            return;
+        }
+
+        const output = await this.pintRunner.sendCommand('df');
+        const frames = this.pintRunner.parseFrameDump(output);
+
+        const stackFrames: StackFrame[] = frames.map((frame, index) => {
+            const sf = new StackFrame(
+                index,
+                frame.name + (frame.typeSuffix ? `@${frame.typeSuffix}` : ''),
+                new Source(
+                    path.basename(this.sourceFile),
+                    this.sourceFile
+                ),
+                frame.currentLine
+            );
+            return sf;
+        });
+
+        response.body = {
+            stackFrames,
+            totalFrames: stackFrames.length
+        };
+        this.sendResponse(response);
+    }
+
+    /**
+     * DAP: Scopes - return locals, parameters, and globals scopes.
+     * We encode the scope type into the variablesReference:
+     *   frameId * 3 + 1 = locals
+     *   frameId * 3 + 2 = parameters
+     *   frameId * 3 + 3 = globals
+     */
+    protected scopesRequest(
+        response: DebugProtocol.ScopesResponse,
+        args: DebugProtocol.ScopesArguments
+    ): void {
+        const frameId = args.frameId;
+        const scopes: Scope[] = [
+            new Scope('Locals', frameId * 3 + 1, false),
+            new Scope('Parameters', frameId * 3 + 2, false),
+            new Scope('Globals', frameId * 3 + 3, false)
+        ];
+
+        response.body = { scopes };
+        this.sendResponse(response);
+    }
+
+    /**
+     * DAP: Variables - fetch variables for a scope using pl/pp/pg.
+     */
+    protected async variablesRequest(
+        response: DebugProtocol.VariablesResponse,
+        args: DebugProtocol.VariablesArguments
+    ): Promise<void> {
+        if (!this.pintRunner) {
+            response.body = { variables: [] };
+            this.sendResponse(response);
+            return;
+        }
+
+        const ref = args.variablesReference;
+        const scopeType = ((ref - 1) % 3) + 1; // 1=locals, 2=params, 3=globals
+        const frameId = Math.floor((ref - 1) / 3);
+
+        let cmd: string;
+        if (scopeType === 1) {
+            // Locals: use "pl" with nesting level
+            cmd = frameId === 0 ? 'pl' : `pl ${frameId + 1}`;
+        } else if (scopeType === 2) {
+            // Parameters: use "pp" with nesting level
+            cmd = frameId === 0 ? 'pp' : `pp ${frameId + 1}`;
+        } else {
+            // Globals: use "pg"
+            cmd = 'pg';
+        }
+
+        const output = await this.pintRunner.sendCommand(cmd);
+        const vars = this.pintRunner.parseVariables(output);
+
+        const variables: Variable[] = vars.map(v => new Variable(v.name, v.value));
+
+        response.body = { variables };
+        this.sendResponse(response);
+    }
+
+    /**
+     * DAP: Evaluate - evaluate an expression using pint's "p" command.
+     */
+    protected async evaluateRequest(
+        response: DebugProtocol.EvaluateResponse,
+        args: DebugProtocol.EvaluateArguments
+    ): Promise<void> {
+        if (!this.pintRunner) {
+            this.sendErrorResponse(response, 4, 'Not connected to pint');
+            return;
+        }
+
+        const expr = args.expression;
+        const output = await this.pintRunner.sendCommand(`p ${expr}`);
+        const result = this.pintRunner.parseExpression(output);
+
+        response.body = {
+            result: result || '(no value)',
+            variablesReference: 0
+        };
+        this.sendResponse(response);
+    }
+
+    /**
+     * DAP: SetVariable - set a variable using pint's "st" command.
+     */
+    protected async setVariableRequest(
+        response: DebugProtocol.SetVariableResponse,
+        args: DebugProtocol.SetVariableArguments
+    ): Promise<void> {
+        if (!this.pintRunner) {
+            this.sendErrorResponse(response, 5, 'Not connected to pint');
+            return;
+        }
+
+        await this.pintRunner.sendCommand(`st ${args.name} ${args.value}`);
+
+        // Read back the new value
+        const output = await this.pintRunner.sendCommand(`p ${args.name}`);
+        const result = this.pintRunner.parseExpression(output);
+
+        response.body = {
+            value: result
+        };
+        this.sendResponse(response);
+    }
+
+    /**
+     * DAP: Continue - resume execution with pint's "r" command.
+     */
+    protected async continueRequest(
+        response: DebugProtocol.ContinueResponse,
+        _args: DebugProtocol.ContinueArguments
+    ): Promise<void> {
+        response.body = { allThreadsContinued: true };
+        this.sendResponse(response);
+        this.continueExecution();
+    }
+
+    /**
+     * Run the program and handle the stopped/exited result.
+     */
+    private async continueExecution(): Promise<void> {
+        if (!this.pintRunner) return;
+
+        const output = await this.pintRunner.sendRun();
+
+        if (output.includes('program complete')) {
+            this.sendEvent(new TerminatedEvent());
+        } else {
+            // Parse the break context
+            const stopped = this.parseStoppedFromOutput(output);
+            if (stopped) {
+                this.sendEvent(new StoppedEvent(stopped.reason, THREAD_ID));
+            }
+        }
+    }
+
+    /**
+     * DAP: Next (step over) - pint's "so" command.
+     */
+    protected async nextRequest(
+        response: DebugProtocol.NextResponse,
+        _args: DebugProtocol.NextArguments
+    ): Promise<void> {
+        this.sendResponse(response);
+        await this.stepExecution('so');
+    }
+
+    /**
+     * DAP: StepIn - pint's "s" command.
+     */
+    protected async stepInRequest(
+        response: DebugProtocol.StepInResponse,
+        _args: DebugProtocol.StepInArguments
+    ): Promise<void> {
+        this.sendResponse(response);
+        await this.stepExecution('s');
+    }
+
+    /**
+     * DAP: StepOut - pint's "ret" command.
+     */
+    protected async stepOutRequest(
+        response: DebugProtocol.StepOutResponse,
+        _args: DebugProtocol.StepOutArguments
+    ): Promise<void> {
+        this.sendResponse(response);
+        await this.stepExecution('ret');
+    }
+
+    /**
+     * Execute a step command and emit the appropriate stopped event.
+     */
+    private async stepExecution(cmd: string): Promise<void> {
+        if (!this.pintRunner) return;
+
+        const output = await this.pintRunner.sendStep(cmd);
+
+        if (output.includes('program complete')) {
+            this.sendEvent(new TerminatedEvent());
+        } else {
+            const stopped = this.parseStoppedFromOutput(output);
+            if (stopped) {
+                this.sendEvent(new StoppedEvent(stopped.reason, THREAD_ID));
+            } else {
+                // Even if we couldn't parse it, we stopped somewhere
+                this.sendEvent(new StoppedEvent('step', THREAD_ID));
+            }
+        }
+    }
+
+    /**
+     * DAP: Pause - send SIGINT to pint.
+     */
+    protected pauseRequest(
+        response: DebugProtocol.PauseResponse,
+        _args: DebugProtocol.PauseArguments
+    ): void {
+        if (this.pintRunner) {
+            this.pintRunner.pause();
+        }
+        this.sendResponse(response);
+    }
+
+    /**
+     * DAP: Terminate - quit pint.
+     */
+    protected terminateRequest(
+        response: DebugProtocol.TerminateResponse,
+        _args: DebugProtocol.TerminateArguments
+    ): void {
+        if (this.pintRunner) {
+            this.pintRunner.dispose();
+            this.pintRunner = null;
+        }
+        this.sendResponse(response);
+    }
+
+    /**
+     * DAP: Disconnect - clean up and exit.
+     */
+    protected disconnectRequest(
+        response: DebugProtocol.DisconnectResponse,
+        _args: DebugProtocol.DisconnectArguments
+    ): void {
+        if (this.pintRunner) {
+            this.pintRunner.dispose();
+            this.pintRunner = null;
+        }
+        this.sendResponse(response);
+    }
+
+    /**
+     * Parse a stopped context from raw pint output.
+     */
+    private parseStoppedFromOutput(output: string): StoppedInfo | null {
+        if (!this.pintRunner) return null;
+
+        const sourceLines = this.pintRunner.parseSourceLines(output);
+        if (sourceLines.length === 0) return null;
+
+        const currentLine = sourceLines.find(l => l.isCurrent);
+        if (!currentLine) return null;
+
+        let reason = 'step';
+        if (output.includes('=== break ===')) {
+            reason = 'breakpoint';
+        } else if (output.includes('*** Program stopped by user break')) {
+            reason = 'pause';
+        }
+
+        return {
+            line: currentLine.lineNumber,
+            reason,
+            sourceContext: sourceLines
+        };
+    }
+}

--- a/vscode-pascaline/src/pintRunner.ts
+++ b/vscode-pascaline/src/pintRunner.ts
@@ -1,0 +1,399 @@
+import { ChildProcess, spawn } from 'child_process';
+import { EventEmitter } from 'events';
+
+/**
+ * Information about a stopped event from pint.
+ */
+export interface StoppedInfo {
+    /** The source line where execution stopped. */
+    line: number;
+    /** The reason for stopping: breakpoint, step, entry, pause, or watch. */
+    reason: string;
+    /** The 3-line source context around the stopped line. */
+    sourceContext: SourceLine[];
+}
+
+/**
+ * A parsed source line from pint debug output.
+ * Format: "  NN:  count: [b][t][*] source text"
+ */
+export interface SourceLine {
+    lineNumber: number;
+    hitCount: number;
+    hasBreakpoint: boolean;
+    hasTracepoint: boolean;
+    isCurrent: boolean;
+    text: string;
+}
+
+/**
+ * A parsed stack frame from pint's "df" command.
+ */
+export interface FrameInfo {
+    /** Block name (e.g., "q", "y", "test"). */
+    name: string;
+    /** Type suffix after @ (e.g., "f_i" for function returning integer). */
+    typeSuffix: string;
+    /** Address in hex. */
+    address: string;
+    /** Source context lines for this frame. */
+    sourceContext: SourceLine[];
+    /** Current source line number for this frame. */
+    currentLine: number;
+}
+
+/**
+ * A parsed variable from pint's pl/pp/pg output.
+ */
+export interface VariableInfo {
+    name: string;
+    value: string;
+}
+
+/**
+ * Manages the pint interpreter subprocess and translates between
+ * text-based pint debug commands and structured TypeScript objects.
+ */
+export class PintRunner extends EventEmitter {
+    private process: ChildProcess | null = null;
+    private outputBuffer: string = '';
+    private commandResolve: ((output: string) => void) | null = null;
+    private running: boolean = false;
+    private disposed: boolean = false;
+
+    /**
+     * Spawn pint with debug mode enabled.
+     * @param pintPath Path to the pint executable.
+     * @param p6File Path to the compiled .p6 intermediate file.
+     * @param outFile Path for program output file.
+     */
+    async start(pintPath: string, p6File: string, outFile: string): Promise<string> {
+        return new Promise((resolve, reject) => {
+            this.process = spawn(pintPath, [
+                p6File, outFile, '--debug', '--debugsrc'
+            ]);
+
+            if (!this.process.stdout || !this.process.stderr || !this.process.stdin) {
+                reject(new Error('Failed to create pint process streams'));
+                return;
+            }
+
+            this.process.stdout.setEncoding('utf8');
+            this.process.stderr.setEncoding('utf8');
+
+            this.process.stdout.on('data', (data: string) => {
+                this.handleOutput(data);
+            });
+
+            this.process.stderr.on('data', (data: string) => {
+                this.emit('stderr', data);
+            });
+
+            this.process.on('error', (err) => {
+                reject(err);
+            });
+
+            this.process.on('exit', (code, signal) => {
+                this.emit('exited', code ?? -1, signal);
+                this.process = null;
+            });
+
+            // Wait for the initial "debug> " prompt
+            this.commandResolve = (output: string) => {
+                resolve(output);
+            };
+        });
+    }
+
+    /**
+     * Send a command to pint and wait for the response (until next "debug> " prompt).
+     */
+    async sendCommand(cmd: string): Promise<string> {
+        if (!this.process || !this.process.stdin) {
+            throw new Error('Pint process not running');
+        }
+
+        return new Promise((resolve) => {
+            this.commandResolve = resolve;
+            this.process!.stdin!.write(cmd + '\n');
+        });
+    }
+
+    /**
+     * Send a run command. This is special because during execution, pint
+     * interleaves program output with debug messages. We need to detect
+     * either a break, program completion, or user-interrupted stop.
+     */
+    async sendRun(): Promise<string> {
+        this.running = true;
+        const result = await this.sendCommand('r');
+        this.running = false;
+        return result;
+    }
+
+    /**
+     * Send a step command (s, so, ret) and wait for the response.
+     */
+    async sendStep(cmd: string): Promise<string> {
+        this.running = true;
+        const result = await this.sendCommand(cmd);
+        this.running = false;
+        return result;
+    }
+
+    /**
+     * Interrupt the running program with SIGINT.
+     */
+    pause(): void {
+        if (this.process) {
+            this.process.kill('SIGINT');
+        }
+    }
+
+    /**
+     * Quit pint and clean up.
+     */
+    dispose(): void {
+        if (this.disposed) return;
+        this.disposed = true;
+
+        if (this.process) {
+            try {
+                this.process.stdin?.write('q\n');
+            } catch {
+                // ignore write errors during shutdown
+            }
+            setTimeout(() => {
+                if (this.process) {
+                    this.process.kill('SIGKILL');
+                    this.process = null;
+                }
+            }, 1000);
+        }
+    }
+
+    /**
+     * Handle raw output from pint's stdout.
+     * Accumulates text until a "debug> " prompt is found, then resolves
+     * the pending command. During run mode, also detects program output,
+     * breaks, and completion.
+     */
+    private handleOutput(data: string): void {
+        this.outputBuffer += data;
+
+        // Check for the debug prompt which signals end of a command response
+        const promptIndex = this.outputBuffer.indexOf('debug> ');
+        if (promptIndex !== -1) {
+            const response = this.outputBuffer.substring(0, promptIndex);
+            this.outputBuffer = this.outputBuffer.substring(promptIndex + 'debug> '.length);
+
+            // During run, extract program output vs debug output
+            if (this.running) {
+                this.extractProgramOutput(response);
+            }
+
+            // Check for program completion
+            if (response.includes('program complete')) {
+                this.emit('exited', 0, null);
+            }
+
+            // Check for break
+            if (response.includes('=== break ===') ||
+                response.includes('*** Program stopped by user break')) {
+                const stopped = this.parseStoppedContext(response);
+                if (stopped) {
+                    this.emit('stopped', stopped);
+                }
+            }
+
+            // Resolve the pending command
+            if (this.commandResolve) {
+                const resolve = this.commandResolve;
+                this.commandResolve = null;
+                resolve(response);
+            }
+        }
+    }
+
+    /**
+     * Extract and emit program output (non-debug text) from a run response.
+     */
+    private extractProgramOutput(response: string): void {
+        const lines = response.split('\n');
+        const programLines: string[] = [];
+
+        for (const line of lines) {
+            // Skip debug-specific output patterns
+            if (line.match(/^\s*\d+:\s+\d+:/) ||     // source line format
+                line.includes('=== break ===') ||
+                line.includes('program complete') ||
+                line.includes('P6 debug mode') ||
+                line.includes('*** Program stopped') ||
+                line.includes('Watch variable:') ||
+                line.trim() === '') {
+                continue;
+            }
+            programLines.push(line);
+        }
+
+        if (programLines.length > 0) {
+            this.emit('output', programLines.join('\n') + '\n');
+        }
+    }
+
+    /**
+     * Parse a stopped context from pint output to extract the current line.
+     */
+    private parseStoppedContext(response: string): StoppedInfo | null {
+        const sourceLines = this.parseSourceLines(response);
+        if (sourceLines.length === 0) return null;
+
+        const currentLine = sourceLines.find(l => l.isCurrent);
+        if (!currentLine) return null;
+
+        let reason = 'step';
+        if (response.includes('=== break ===')) {
+            reason = currentLine.hasBreakpoint ? 'breakpoint' : 'breakpoint';
+        } else if (response.includes('*** Program stopped by user break')) {
+            reason = 'pause';
+        }
+
+        return {
+            line: currentLine.lineNumber,
+            reason,
+            sourceContext: sourceLines
+        };
+    }
+
+    // ========================================================================
+    // Output parsing helpers
+    // ========================================================================
+
+    /**
+     * Parse source lines from pint output.
+     * Format: "  NN:  count: [b][t][*] source text"
+     */
+    parseSourceLines(output: string): SourceLine[] {
+        const lines = output.split('\n');
+        const result: SourceLine[] = [];
+        // Match: optional spaces, line number, colon, spaces, hit count, colon,
+        // optional flags (b, t, *), then source text
+        const pattern = /^\s*(\d+):\s+(\d+):\s*(b?)(t?)(\*?)\s*(.*)/;
+
+        for (const line of lines) {
+            const m = line.match(pattern);
+            if (m) {
+                result.push({
+                    lineNumber: parseInt(m[1], 10),
+                    hitCount: parseInt(m[2], 10),
+                    hasBreakpoint: m[3] === 'b',
+                    hasTracepoint: m[4] === 't',
+                    isCurrent: m[5] === '*',
+                    text: m[6]
+                });
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Parse stack frames from pint's "df" command output.
+     * Format:
+     *   name@type: addr: XXXXXXXX locals/stack: RANGE (size)
+     *     NN: count: [b][t][*] source text
+     *     ...
+     */
+    parseFrameDump(output: string): FrameInfo[] {
+        const frames: FrameInfo[] = [];
+        const lines = output.split('\n');
+        let currentFrame: FrameInfo | null = null;
+
+        // Frame header: "name@type: addr: XXXXXXXX locals/stack: ..."
+        // or just "name: addr: XXXXXXXX locals/stack: ..." for program-level
+        const framePattern = /^(\w+)(?:@(\w+))?:\s*addr:\s*([0-9A-Fa-f]+)\s+locals\/stack:/;
+        const sourcePattern = /^\s*(\d+):\s+(\d+):\s*(b?)(t?)(\*?)\s*(.*)/;
+
+        for (const line of lines) {
+            const fm = line.match(framePattern);
+            if (fm) {
+                currentFrame = {
+                    name: fm[1],
+                    typeSuffix: fm[2] || '',
+                    address: fm[3],
+                    sourceContext: [],
+                    currentLine: 0
+                };
+                frames.push(currentFrame);
+                continue;
+            }
+
+            if (currentFrame) {
+                const sm = line.match(sourcePattern);
+                if (sm) {
+                    const sl: SourceLine = {
+                        lineNumber: parseInt(sm[1], 10),
+                        hitCount: parseInt(sm[2], 10),
+                        hasBreakpoint: sm[3] === 'b',
+                        hasTracepoint: sm[4] === 't',
+                        isCurrent: sm[5] === '*',
+                        text: sm[6]
+                    };
+                    currentFrame.sourceContext.push(sl);
+                    if (sl.isCurrent) {
+                        currentFrame.currentLine = sl.lineNumber;
+                    }
+                }
+            }
+        }
+
+        return frames;
+    }
+
+    /**
+     * Parse variable listings from pint's pl/pp/pg output.
+     * Format:
+     *   Locals for block: name
+     *
+     *   varname                    value
+     *   ...
+     *
+     * Or for globals:
+     *   Globals:
+     *   varname                    value
+     */
+    parseVariables(output: string): VariableInfo[] {
+        const vars: VariableInfo[] = [];
+        const lines = output.split('\n');
+
+        for (const line of lines) {
+            // Skip headers and blank lines
+            if (line.trim() === '' ||
+                line.startsWith('Locals for block:') ||
+                line.startsWith('Parameters for block:') ||
+                line.startsWith('Globals:')) {
+                continue;
+            }
+
+            // Variable line: name followed by spaces then value
+            // The name is left-aligned, value is after whitespace
+            const m = line.match(/^(\S+)\s{2,}(.+)/);
+            if (m) {
+                vars.push({
+                    name: m[1],
+                    value: m[2].trim()
+                });
+            }
+        }
+
+        return vars;
+    }
+
+    /**
+     * Parse expression result from pint's "p" command output.
+     * The value appears on the line(s) after the command.
+     */
+    parseExpression(output: string): string {
+        const lines = output.split('\n').filter(l => l.trim() !== '');
+        return lines.join('\n').trim();
+    }
+}

--- a/vscode-pascaline/tsconfig.json
+++ b/vscode-pascaline/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "out",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "out"]
+}


### PR DESCRIPTION
## Summary
- Adds a Debug Adapter Protocol (DAP) adapter to the Pascaline VS Code extension
- Wraps pint's built-in text debugger, translating DAP JSON messages to pint commands via stdin/stdout
- Supports breakpoints, step over/into/out, continue, pause, variable inspection (locals/params/globals), call stack, and expression evaluation

## Architecture
```
VS Code  <--DAP JSON-->  TypeScript Debug Adapter  <--stdin/stdout-->  pint
```

## Files
| File | Purpose |
|------|---------|
| `src/pintRunner.ts` | Pint subprocess lifecycle, command sending, output parsing |
| `src/pascalineDebug.ts` | DAP `DebugSession` subclass with all request handlers |
| `src/extension.ts` | Extension activation, inline debug adapter factory |
| `tsconfig.json` | TypeScript build config |
| `.vscodeignore` | Packaging exclusions |
| `package.json` | Updated with debugger contribution, dependencies, build scripts |

## DAP-to-pint command mapping
| DAP Request | pint Command |
|---|---|
| setBreakpoints | `c` then `b [module] <line>` |
| continue | `r` |
| next (step over) | `so` |
| stepIn | `s` |
| stepOut | `ret` |
| pause | SIGINT |
| stackTrace | `df` |
| variables | `pl` / `pp` / `pg` |
| evaluate | `p <expr>` |

## Test plan
- [ ] Build: `cd vscode-pascaline && npm install && npm run build`
- [ ] Load extension in VS Code: `code --extensionDevelopmentPath=./vscode-pascaline`
- [ ] Set breakpoint in a `.pas` file and press F5
- [ ] Verify stepping, variable inspection, call stack
- [ ] Test with `sample_programs/roman.pas` (has procedure calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)