### PR TITLE
Fix stale psystem paths in p6 --pgen link (refs #177)

### DIFF
--- a/bin/p6
+++ b/bin/p6
@@ -162,8 +162,10 @@ elif [ "$package" = "1" ]; then
 elif [ "$pgen" = "1" ]; then
 
 	echo Running with pgen
-    gcc -g3 -DWRDSIZ64 $PASCALP6/source/AMD64/gcc/psystem.c \
-        $PASCALP6/source/AMD64/gcc/psystem_asm.s $objects -o $progfile -lm
+    gcc -g3 -DWRDSIZ64 -DLENDIAN -DPASCALINE -DNOPRDPRR -DNOHEADER \
+        $PASCALP6/source/pgen/psystem.c \
+        -x assembler $PASCALP6/source/pgen/amd64/psystem.asm -x none \
+        $objects -o $progfile -lm
     ./$progfile
 
 else

--- a/hosts/pascaline/bit64/p6
+++ b/hosts/pascaline/bit64/p6
@@ -157,8 +157,10 @@ elif [ "$package" = "1" ]; then
 elif [ "$pgen" = "1" ]; then
 
 	echo Running with pgen
-    gcc -g3 -DWRDSIZ64 $PASCALP6/source/AMD64/gcc/psystem.c \
-        $PASCALP6/source/AMD64/gcc/psystem_asm.s $objects -o $progfile -lm
+    gcc -g3 -DWRDSIZ64 -DLENDIAN -DPASCALINE -DNOPRDPRR -DNOHEADER \
+        $PASCALP6/source/pgen/psystem.c \
+        -x assembler $PASCALP6/source/pgen/amd64/psystem.asm -x none \
+        $objects -o $progfile -lm
     ./$progfile
 
 else


### PR DESCRIPTION
The `--pgen` path of the `p6` driver linked against `source/AMD64/gcc/psystem.c` and `source/AMD64/gcc/psystem_asm.s`. A refactor relocated those to `source/pgen/psystem.c` and `source/pgen/amd64/psystem.asm`, so `p6 --pgen <prog>` failed with:

```
gcc: error: .../source/AMD64/gcc/psystem.c: No such file or directory
gcc: error: .../source/AMD64/gcc/psystem_asm.s: No such file or directory
```

This points the two tracked drivers (`bin/p6`, `hosts/pascaline/bit64/p6`) at the current files, matching the Makefile's psystem recipe: the `CPPFLAGS64LE` defines (`-DLENDIAN -DPASCALINE -DNOPRDPRR -DNOHEADER`) and `-x assembler` for the `.asm` (which gcc does not auto-recognize). Verified the "No such file" errors are gone and `source/pgen/psystem.c` now compiles in the link step.

Part of #177. Two further blockers on the `--pgen` out-of-box path remain and are documented in that issue (missing `main.o` startup shim in the link; pgen "Calling convention mismatch").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
