### PR TITLE
compile: take output dir as --out=<dir> instead of REGRESS_OUT env

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,9 +11,9 @@
 # per-mode products (the machine deck <file>.p6o, assembly/object files, and the
 # executable). This does not run the program.
 #
-# When REGRESS_OUT is set, all generated products and the .err are placed in
-# that directory (via pc -buildpath / -errfile) so models can build in parallel;
-# the source is still read from its own path.
+# When --out=<dir> is given, all generated products and the .err are placed in
+# that directory (via pc -buildpath) so models can build in parallel; the source
+# is still read from its own path. Without --out they go alongside the source.
 #
 # The flags are one of:
 #
@@ -24,6 +24,8 @@
 # --pgen     Generate a native executable for the current machine (default).
 # --noerrmsg Do not echo the .err file on completion (the file is still written).
 # --iso7185  Compile in ISO 7185 standard mode.
+# --out=<dir> Place generated products and the .err in <dir> (default: alongside
+#            the source). Used by the regression to give each model its own dir.
 #
 # All other options are passed through to the compiler.
 #
@@ -31,6 +33,7 @@
 mode=pgen
 noerrmsg=0
 listing=0
+outdir=""
 prog=""
 pcflags=""
 
@@ -48,6 +51,7 @@ do
         --iso7185)  pcflags="$pcflags -iso7185" ;;
         --list+|--list) listing=1 ;;  # listing on; redirected via --list= below
         --list-)    listing=0 ;;       # listing off; errors-only via -ef= below
+        --out=*)    outdir="${param#--out=}" ;;  # output/build directory
         -*)         pcflags="$pcflags $param" ;;  # pass other options through
         *)          prog="$param" ;;
 
@@ -63,14 +67,14 @@ if [ -z "$prog" ]; then
 fi
 
 #
-# Output location: a REGRESS_OUT directory (for parallel per-model builds) or,
+# Output location: the --out=<dir> directory (for parallel per-model builds) or,
 # by default, alongside the source. pc reads the source in place and writes the
 # generated products and the .err to the build path.
 #
-if [ -n "$REGRESS_OUT" ]; then
+if [ -n "$outdir" ]; then
 
-    buildpath="-bp=$REGRESS_OUT"
-    err="$REGRESS_OUT/$(basename "$prog").err"
+    buildpath="-bp=$outdir"
+    err="$outdir/$(basename "$prog").err"
 
 else
 
@@ -107,8 +111,8 @@ status=$?
 #
 if [ ! -f "$err" ]; then
 
-    if [ -n "$REGRESS_OUT" ]; then
-        p6out="$REGRESS_OUT/$(basename "$prog").p6"
+    if [ -n "$outdir" ]; then
+        p6out="$outdir/$(basename "$prog").p6"
     else
         p6out="$prog.p6"
     fi

--- a/bin/cpcoms
+++ b/bin/cpcoms
@@ -20,7 +20,7 @@ cpp -DSELF_COMPILE -DWRDSIZ64 -P -nostdinc -traditional-cpp source/pcom.pas $(ob
 # Compile pcom to intermediate code using its binary version.
 #
 echo Compiling pcom to intermediate code
-compile $1 $(ob source/pcom.mpp)
+compile --out="$REGRESS_OUT" $1 $(ob source/pcom.mpp)
 if [ $? -ne 0 ]
 then
 

--- a/bin/cpints
+++ b/bin/cpints
@@ -22,7 +22,7 @@ cpp -DSELF_COMPILE -DWRDSIZ64 -P -nostdinc -traditional-cpp source/pint.pas $(ob
 # canonically; compile redirects its products into REGRESS_OUT.
 #
 echo Compiling the ISO 7185 PAT
-compile $1 standard_tests/iso7185pat
+compile --out="$REGRESS_OUT" $1 standard_tests/iso7185pat
 if [ $? -ne 0 ]
 then
 
@@ -35,7 +35,7 @@ fi
 # Compile pint itself
 #
 echo Compiling pint to intermediate code
-compile $1 $(ob source/pint.mpp)
+compile --out="$REGRESS_OUT" $1 $(ob source/pint.mpp)
 if [ $? -ne 0 ]
 then
 

--- a/bin/testp2
+++ b/bin/testp2
@@ -18,7 +18,7 @@ ob() { if [ -n "$REGRESS_OUT" ]; then echo "$REGRESS_OUT/$(basename "$1")"; else
 amdopt=""
 if [ "$1" = "--pgen" ]; then amdopt="--amd64_sysv"; fi
 echo "Compiling pcomp to intermediate code"
-compile --list- $1 $amdopt p2/pcomp
+compile --out="$REGRESS_OUT" --list- $1 $amdopt p2/pcomp
 cat $(ob p2/pcomp).err
 #
 # Run the p2 compiler to get p2 intermediate
@@ -35,7 +35,7 @@ fi
 # Compile pasint to intermediate code
 #
 echo Compiling pasint to intermediate
-compile --list- --reference- $1 $amdopt p2/pasint
+compile --out="$REGRESS_OUT" --list- --reference- $1 $amdopt p2/pasint
 cat $(ob p2/pasint).err
 #
 # Create null input file

--- a/bin/testp4
+++ b/bin/testp4
@@ -17,7 +17,7 @@ ob() { if [ -n "$REGRESS_OUT" ]; then echo "$REGRESS_OUT/$(basename "$1")"; else
 amdopt=""
 if [ "$1" = "--pgen" ]; then amdopt="--amd64_sysv"; fi
 echo "Compiling pcom to intermediate code"
-compile --list- $1 $amdopt p4/pcom
+compile --out="$REGRESS_OUT" --list- $1 $amdopt p4/pcom
 cat $(ob p4/pcom).err
 #
 # Run the p4 compiler to get p4 intermediate
@@ -31,7 +31,7 @@ fi
 # Compile pint
 #
 echo Compiling pint to intermediate code
-compile --list- $1 $amdopt p4/pint
+compile --out="$REGRESS_OUT" --list- $1 $amdopt p4/pint
 #
 # Create null input file
 #

--- a/bin/testp5
+++ b/bin/testp5
@@ -22,7 +22,7 @@ ob() { if [ -n "$REGRESS_OUT" ]; then echo "$REGRESS_OUT/$(basename "$1")"; else
 #
 echo "Compiling pcom to intermediate code"
 cpp -DWRDSIZ64 -P -nostdinc -traditional-cpp p5/source/pcom.pas $(ob p5/source/pcom.mpp).pas
-compile --list- $1 $(ob p5/source/pcom.mpp)
+compile --out="$REGRESS_OUT" --list- $1 $(ob p5/source/pcom.mpp)
 cat $(ob p5/source/pcom.mpp).err
 #
 # Run P5/pcom on P6/pint to compile iso7185pat to P5/intermediate
@@ -33,7 +33,7 @@ pint $(ob p5/source/pcom.mpp).p6 ${tmpd}temp standard_tests/iso7185pat.pas $(ob 
 #
 echo "Compiling pint to intermediate code"
 cpp -DSMALL_MODEL -DWRDSIZ64 -P -nostdinc -traditional-cpp p5/source/pint.pas $(ob p5/source/pint.mpp).pas
-compile --list- $1 $(ob p5/source/pint.mpp)
+compile --out="$REGRESS_OUT" --list- $1 $(ob p5/source/pint.mpp)
 cat $(ob p5/source/pint.mpp).err
 #
 # Create null input file

--- a/bin/testp6
+++ b/bin/testp6
@@ -24,7 +24,7 @@ ob() { if [ -n "$REGRESS_OUT" ]; then echo "$REGRESS_OUT/$(basename "$1")"; else
 #
 echo "Compiling pcom to intermediate code"
 cpp -DWRDSIZ64 -P -nostdinc -traditional-cpp source/pcom.pas $(ob source/pcom.mpp).pas
-compile --list- $1 $(ob source/pcom.mpp)
+compile --out="$REGRESS_OUT" --list- $1 $(ob source/pcom.mpp)
 cat $(ob source/pcom.mpp).err
 #
 # Run P6/pcom on P6/pint to compile iso7185pat to P6/intermediate
@@ -35,7 +35,7 @@ pint $(ob source/pcom.mpp).p6 ${tmpd}temp standard_tests/iso7185pat.pas $(ob sou
 #
 echo "Compiling pint to intermediate code"
 cpp -DSHORT_STORE -DWRDSIZ64 -P -nostdinc -traditional-cpp source/pint.pas $(ob source/pint.mpp).pas
-compile --list- $1 $(ob source/pint.mpp)
+compile --out="$REGRESS_OUT" --list- $1 $(ob source/pint.mpp)
 cat $(ob source/pint.mpp).err
 #
 # Create null input file

--- a/bin/testpascaline
+++ b/bin/testpascaline
@@ -70,7 +70,7 @@ else
 
     # form combined intermediate
     #echo "Will execute: compile $param1 pascaline2 pascaline1 pascaline"
-    compile $param1 pascaline2 pascaline1 pascaline
+    compile --out="$REGRESS_OUT" $param1 pascaline2 pascaline1 pascaline
 
 fi
 

--- a/bin/testpascals
+++ b/bin/testpascals
@@ -17,7 +17,7 @@ ob() { if [ -n "$REGRESS_OUT" ]; then echo "$REGRESS_OUT/$(basename "$1")"; else
 amdopt=""
 if [ "$1" = "--pgen" ]; then amdopt="--amd64_sysv"; fi
 echo "Compiling pascals to intermediate code"
-compile --list- $1 $amdopt sample_programs/pascals
+compile --out="$REGRESS_OUT" --list- $1 $amdopt sample_programs/pascals
 cat $(ob sample_programs/pascals).err
 #
 # Create null input file

--- a/bin/testprog
+++ b/bin/testprog
@@ -203,7 +203,7 @@ do
     		#echo "Compiling $param..."
             # clean any previous products
             rm -f $(ob $param).lst $(ob $param).dif $(ob $param).ecd
-    		compile $listoption --noerrmsg $options $pintoption $pmachoption \
+    		compile --out="$REGRESS_OUT" $listoption --noerrmsg $options $pintoption $pmachoption \
                 $cmachoption $packageoption $pgenoption $param
     		if [ $? -ne 0 ]; then
     		

--- a/hosts/pascaline/compile
+++ b/hosts/pascaline/compile
@@ -11,9 +11,9 @@
 # per-mode products (the machine deck <file>.p6o, assembly/object files, and the
 # executable). This does not run the program.
 #
-# When REGRESS_OUT is set, all generated products and the .err are placed in
-# that directory (via pc -buildpath / -errfile) so models can build in parallel;
-# the source is still read from its own path.
+# When --out=<dir> is given, all generated products and the .err are placed in
+# that directory (via pc -buildpath) so models can build in parallel; the source
+# is still read from its own path. Without --out they go alongside the source.
 #
 # The flags are one of:
 #
@@ -24,6 +24,8 @@
 # --pgen     Generate a native executable for the current machine (default).
 # --noerrmsg Do not echo the .err file on completion (the file is still written).
 # --iso7185  Compile in ISO 7185 standard mode.
+# --out=<dir> Place generated products and the .err in <dir> (default: alongside
+#            the source). Used by the regression to give each model its own dir.
 #
 # All other options are passed through to the compiler.
 #
@@ -31,6 +33,7 @@
 mode=pgen
 noerrmsg=0
 listing=0
+outdir=""
 prog=""
 pcflags=""
 
@@ -48,6 +51,7 @@ do
         --iso7185)  pcflags="$pcflags -iso7185" ;;
         --list+|--list) listing=1 ;;  # listing on; redirected via --list= below
         --list-)    listing=0 ;;       # listing off; errors-only via -ef= below
+        --out=*)    outdir="${param#--out=}" ;;  # output/build directory
         -*)         pcflags="$pcflags $param" ;;  # pass other options through
         *)          prog="$param" ;;
 
@@ -63,14 +67,14 @@ if [ -z "$prog" ]; then
 fi
 
 #
-# Output location: a REGRESS_OUT directory (for parallel per-model builds) or,
+# Output location: the --out=<dir> directory (for parallel per-model builds) or,
 # by default, alongside the source. pc reads the source in place and writes the
 # generated products and the .err to the build path.
 #
-if [ -n "$REGRESS_OUT" ]; then
+if [ -n "$outdir" ]; then
 
-    buildpath="-bp=$REGRESS_OUT"
-    err="$REGRESS_OUT/$(basename "$prog").err"
+    buildpath="-bp=$outdir"
+    err="$outdir/$(basename "$prog").err"
 
 else
 
@@ -107,8 +111,8 @@ status=$?
 #
 if [ ! -f "$err" ]; then
 
-    if [ -n "$REGRESS_OUT" ]; then
-        p6out="$REGRESS_OUT/$(basename "$prog").p6"
+    if [ -n "$outdir" ]; then
+        p6out="$outdir/$(basename "$prog").p6"
     else
         p6out="$prog.p6"
     fi

--- a/hosts/pascaline/testp2
+++ b/hosts/pascaline/testp2
@@ -18,7 +18,7 @@ ob() { if [ -n "$REGRESS_OUT" ]; then echo "$REGRESS_OUT/$(basename "$1")"; else
 amdopt=""
 if [ "$1" = "--pgen" ]; then amdopt="--amd64_sysv"; fi
 echo "Compiling pcomp to intermediate code"
-compile --list- $1 $amdopt p2/pcomp
+compile --out="$REGRESS_OUT" --list- $1 $amdopt p2/pcomp
 cat $(ob p2/pcomp).err
 #
 # Run the p2 compiler to get p2 intermediate
@@ -35,7 +35,7 @@ fi
 # Compile pasint to intermediate code
 #
 echo Compiling pasint to intermediate
-compile --list- --reference- $1 $amdopt p2/pasint
+compile --out="$REGRESS_OUT" --list- --reference- $1 $amdopt p2/pasint
 cat $(ob p2/pasint).err
 #
 # Create null input file

--- a/hosts/pascaline/testp4
+++ b/hosts/pascaline/testp4
@@ -17,7 +17,7 @@ ob() { if [ -n "$REGRESS_OUT" ]; then echo "$REGRESS_OUT/$(basename "$1")"; else
 amdopt=""
 if [ "$1" = "--pgen" ]; then amdopt="--amd64_sysv"; fi
 echo "Compiling pcom to intermediate code"
-compile --list- $1 $amdopt p4/pcom
+compile --out="$REGRESS_OUT" --list- $1 $amdopt p4/pcom
 cat $(ob p4/pcom).err
 #
 # Run the p4 compiler to get p4 intermediate
@@ -31,7 +31,7 @@ fi
 # Compile pint
 #
 echo Compiling pint to intermediate code
-compile --list- $1 $amdopt p4/pint
+compile --out="$REGRESS_OUT" --list- $1 $amdopt p4/pint
 #
 # Create null input file
 #

--- a/hosts/pascaline/testp5
+++ b/hosts/pascaline/testp5
@@ -22,7 +22,7 @@ ob() { if [ -n "$REGRESS_OUT" ]; then echo "$REGRESS_OUT/$(basename "$1")"; else
 #
 echo "Compiling pcom to intermediate code"
 cpp -DWRDSIZ64 -P -nostdinc -traditional-cpp p5/source/pcom.pas $(ob p5/source/pcom.mpp).pas
-compile --list- $1 $(ob p5/source/pcom.mpp)
+compile --out="$REGRESS_OUT" --list- $1 $(ob p5/source/pcom.mpp)
 cat $(ob p5/source/pcom.mpp).err
 #
 # Run P5/pcom on P6/pint to compile iso7185pat to P5/intermediate
@@ -33,7 +33,7 @@ pint $(ob p5/source/pcom.mpp).p6 ${tmpd}temp standard_tests/iso7185pat.pas $(ob 
 #
 echo "Compiling pint to intermediate code"
 cpp -DSMALL_MODEL -DWRDSIZ64 -P -nostdinc -traditional-cpp p5/source/pint.pas $(ob p5/source/pint.mpp).pas
-compile --list- $1 $(ob p5/source/pint.mpp)
+compile --out="$REGRESS_OUT" --list- $1 $(ob p5/source/pint.mpp)
 cat $(ob p5/source/pint.mpp).err
 #
 # Create null input file

--- a/hosts/pascaline/testp6
+++ b/hosts/pascaline/testp6
@@ -24,7 +24,7 @@ ob() { if [ -n "$REGRESS_OUT" ]; then echo "$REGRESS_OUT/$(basename "$1")"; else
 #
 echo "Compiling pcom to intermediate code"
 cpp -DWRDSIZ64 -P -nostdinc -traditional-cpp source/pcom.pas $(ob source/pcom.mpp).pas
-compile --list- $1 $(ob source/pcom.mpp)
+compile --out="$REGRESS_OUT" --list- $1 $(ob source/pcom.mpp)
 cat $(ob source/pcom.mpp).err
 #
 # Run P6/pcom on P6/pint to compile iso7185pat to P6/intermediate
@@ -35,7 +35,7 @@ pint $(ob source/pcom.mpp).p6 ${tmpd}temp standard_tests/iso7185pat.pas $(ob sou
 #
 echo "Compiling pint to intermediate code"
 cpp -DSHORT_STORE -DWRDSIZ64 -P -nostdinc -traditional-cpp source/pint.pas $(ob source/pint.mpp).pas
-compile --list- $1 $(ob source/pint.mpp)
+compile --out="$REGRESS_OUT" --list- $1 $(ob source/pint.mpp)
 cat $(ob source/pint.mpp).err
 #
 # Create null input file

--- a/regress_report.txt
+++ b/regress_report.txt
@@ -1,5 +1,5 @@
 ************ Regression Summary *************
-Sun 28 Jun 2026 01:56:32 PM PDT
+Sun 28 Jun 2026 04:16:30 PM PDT
 Line counts should be 0 for pass
 pint run ***************************************
 0 sample_programs/test_results/pint/hello.dif
@@ -127,12 +127,12 @@ network_test run
 
 Total differences: 0
 Fails: 0
-Sun 28 Jun 2026 02:01:51 PM PDT
+Sun 28 Jun 2026 04:21:53 PM PDT
 Files sha256sum ***************************************
 Source files
 9e6bc2bc0202ff3f2d0f2908311b4351171949eafc2e7cda51a89ee9dbab5d0d  -
 batch files
-42a2442babf14898de8dd66c8fc44355c46017ef0f86145a5fcdf247f9356e6a  -
+587f3f7d274002745a153f07f450ca61df0b8345f88981ad6648f2af85db8036  -
 P2 files
 abb5a8a00d377dbcf7c793f9f399fb51e017f2e27ecab9607e4cace253472cfb  -
 p4 files


### PR DESCRIPTION
## Summary

Removes `compile`'s reliance on the `REGRESS_OUT` environment variable. The per-model output directory is now passed explicitly as a `--out=<dir>` command-line option.

## What changed

**`bin/compile`** — no longer reads `REGRESS_OUT`. Adds `--out=<dir>`: when given, the build path (`pc -bp`) and the `.err` go to that directory; without it, products go alongside the source (unchanged).

**The regression runners** — `testprog`, `testpascals`, `testp2`/`testp4`/`testp5`/`testp6`, `cpints`, `cpcoms`, `testpascaline` now pass `--out="$REGRESS_OUT"` at each `compile` call (14 sites). They still read `REGRESS_OUT` for their own products; only `compile`'s coupling moves to the explicit option.

## Validation

- `testpascals --pgen` passes both standalone (products alongside source) and with `REGRESS_OUT` set (products in the per-model dir, no leak to the source tree).
- `testprt --pint` = 0 diffs (the deviance/run path through testprog → compile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
