### PR TITLE
Base regression verdict on output comparison, not run exit status (#252)

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -163,6 +163,10 @@ if [ ! -f "$progfile.inp" ]; then
 
 fi
 
+# The run result is the exit status of the selected backend, captured before the
+# trailing cleanup and listing can clobber $? -- otherwise a stray rm/cat failure
+# is misreported as a compile/run failure (issue #252).
+rc=0
 if [ "$pmach" = "1" ]; then
 
 	echo Running with pmach
@@ -171,6 +175,7 @@ if [ "$pmach" = "1" ]; then
     pint ${tmpd}temp2.p6 $obase.p6o > ${tmpd}temp
     cat $obase.p6o $progfile.dat > ${tmpd}temp.p6o
     pmach ${tmpd}temp.p6o $obase.out $options < $progfile.inp &> $obase.lst
+    rc=$? # capture the run result before cleanup clobbers it
     rm ${tmpd}temp ${tmpd}temp2.p6
 
 elif [ "$cmach" = "1" ]; then
@@ -178,23 +183,27 @@ elif [ "$cmach" = "1" ]; then
 	echo Running with cmach
     pint $obase.p6 $obase.p6o --machdeck > ${tmpd}temp
     cmach $obase.p6o $options $progfile.dat $obase.out < $progfile.inp &> $obase.lst
+    rc=$? # capture the run result before cleanup clobbers it
     rm ${tmpd}temp
 
 elif [ "$package" = "1" ]; then
 
     echo Running with package
     ./$obase $options $progfile.dat $obase.out < $progfile.inp &> $obase.lst
+    rc=$?
 
 elif [ "$pgen" = "1" ]; then
 
     echo Running with pgen
     ./$obase $progfile.dat $obase.out $options < $progfile.inp &> $obase.lst
+    rc=$?
 
 else
 
 	echo Running with pint
     cat $obase.p6 $progfile.dat > ${tmpd}temp.p6
     pint ${tmpd}temp.p6 $obase.out $options < $progfile.inp &> $obase.lst
+    rc=$? # capture the run result before cleanup clobbers it
     rm ${tmpd}temp.p6
 
 fi
@@ -207,3 +216,5 @@ if [ "$nolist" = "0" ]; then
     cat $obase.lst
 
 fi
+
+exit $rc

--- a/bin/testprog
+++ b/bin/testprog
@@ -276,12 +276,15 @@ fi
 echo "Running $progfile..."
 # echo "run $pmachoption $cmachoption $options $progfile"
 run --nolist $pintoption $pmachoption $cmachoption $packageoption $pgenoption $options $progfile
-if [ $? -eq 0 ]; then
 
-    #
-    # Check output matches the compare file
-    #
-    strip $(ob $progfile).lst ${tmpd}tmp1
+#
+# The verdict is the output comparison below, not run's exit status: a program
+# under test may legitimately exit non-zero (e.g. a runtime-error test whose
+# expected message is part of the golden), and a stray cleanup hiccup in run
+# must not count as a failure (issue #252). A genuine run failure shows up as a
+# mismatch against the golden.
+#
+strip $(ob $progfile).lst ${tmpd}tmp1
     strip $cmpfile.cmp ${tmpd}tmp2
     dif -w ${tmpd}tmp1 ${tmpd}tmp2 > $(ob $progfile).dif
     rm -f ${tmpd}tmp1
@@ -301,9 +304,3 @@ if [ $? -eq 0 ]; then
     else
         echo "PASS"
     fi
-
-else
-
-    exit 1
-
-fi

--- a/hosts/pascaline/run
+++ b/hosts/pascaline/run
@@ -163,6 +163,10 @@ if [ ! -f "$progfile.inp" ]; then
 
 fi
 
+# The run result is the exit status of the selected backend, captured before the
+# trailing cleanup and listing can clobber $? -- otherwise a stray rm/cat failure
+# is misreported as a compile/run failure (issue #252).
+rc=0
 if [ "$pmach" = "1" ]; then
 
 	echo Running with pmach
@@ -171,6 +175,7 @@ if [ "$pmach" = "1" ]; then
     pint ${tmpd}temp2.p6 $obase.p6o > ${tmpd}temp
     cat $obase.p6o $progfile.dat > ${tmpd}temp.p6o
     pmach ${tmpd}temp.p6o $obase.out $options < $progfile.inp &> $obase.lst
+    rc=$? # capture the run result before cleanup clobbers it
     rm ${tmpd}temp ${tmpd}temp2.p6
 
 elif [ "$cmach" = "1" ]; then
@@ -178,23 +183,27 @@ elif [ "$cmach" = "1" ]; then
 	echo Running with cmach
     pint $obase.p6 $obase.p6o --machdeck > ${tmpd}temp
     cmach $obase.p6o $options $progfile.dat $obase.out < $progfile.inp &> $obase.lst
+    rc=$? # capture the run result before cleanup clobbers it
     rm ${tmpd}temp
 
 elif [ "$package" = "1" ]; then
 
     echo Running with package
     ./$obase $options $progfile.dat $obase.out < $progfile.inp &> $obase.lst
+    rc=$?
 
 elif [ "$pgen" = "1" ]; then
 
     echo Running with pgen
     ./$obase $progfile.dat $obase.out $options < $progfile.inp &> $obase.lst
+    rc=$?
 
 else
 
 	echo Running with pint
     cat $obase.p6 $progfile.dat > ${tmpd}temp.p6
     pint ${tmpd}temp.p6 $obase.out $options < $progfile.inp &> $obase.lst
+    rc=$? # capture the run result before cleanup clobbers it
     rm ${tmpd}temp.p6
 
 fi
@@ -207,3 +216,5 @@ if [ "$nolist" = "0" ]; then
     cat $obase.lst
 
 fi
+
+exit $rc

--- a/regress_report.txt
+++ b/regress_report.txt
@@ -1,5 +1,5 @@
 ************ Regression Summary *************
-Sun 28 Jun 2026 05:36:09 PM PDT
+Sun 28 Jun 2026 08:09:09 PM PDT
 Line counts should be 0 for pass
 pint run ***************************************
 0 sample_programs/test_results/pint/hello.dif
@@ -127,12 +127,12 @@ network_test run
 
 Total differences: 0
 Fails: 0
-Sun 28 Jun 2026 05:41:32 PM PDT
+Sun 28 Jun 2026 08:14:30 PM PDT
 Files sha256sum ***************************************
 Source files
 9e6bc2bc0202ff3f2d0f2908311b4351171949eafc2e7cda51a89ee9dbab5d0d  -
 batch files
-e014885f230d41f0b7704e8e21bd088174976a7ea70ec55c383b6de74c69d570  -
+fb68ddf64c1a2c291f37a0020cb45090cddbe8d9c7918f428bee67af5fb49a4a  -
 P2 files
 abb5a8a00d377dbcf7c793f9f399fb51e017f2e27ecab9607e4cace253472cfb  -
 p4 files


### PR DESCRIPTION
## Summary

Fixes #252 — the transient "compile/run fail" where the program clearly compiled (`.err` = 0 errors) and ran (full output in `.lst`), yet the harness reported failure ("inaccurate error result reporting").

## Root cause

The verdict depended on a fragile exit-status chain:

- `bin/run` ends each backend branch with cleanup (`rm`) and, when not `--nolist`, a trailing `cat $obase.lst`, and had no explicit `exit`. So run's exit status was that **trailing command's**, not the backend's.
- `bin/testprog` did `run …; if [ $? -eq 0 ]; then compare; else exit 1`.

So any stray hiccup in the trailing `rm`/`cat` made run non-zero → testprog hard-failed → "compile/run fail", even though the run succeeded. (`hello.lst` showing the program's output proves the run executed; the false fail was strictly *after* it.)

The exit code can't be the verdict anyway: runtime-error tests intentionally exit non-zero with their expected message in the golden — they passed before only because the cleanup masked the backend status.

## Change

- `bin/run`: capture the selected backend's exit status before cleanup and `exit` with it — run now reports the program's real result.
- `bin/testprog`: drop the gate on run's exit. After a successful compile, always compare the output to the golden; the `.dif` (empty = pass) is the sole verdict. A genuine run failure surfaces as a golden mismatch.

## Validation

Full regression: **0 differences, 0 fails** — runtime-error tests still pass under the output-based verdict.

Scripts-only change (`bin/run`, `bin/testprog`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
