### PR TITLE
graphics_test: refer() unused w in filled-shape speed tests

### DIFF
--- a/libs/tests/graphics_test.pas
+++ b/libs/tests/graphics_test.pas
@@ -740,6 +740,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;
@@ -771,6 +772,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;
@@ -835,6 +837,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;
@@ -907,6 +910,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;
@@ -946,6 +950,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;
@@ -984,6 +989,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;
@@ -1016,6 +1022,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;
@@ -1053,6 +1060,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;
@@ -1086,6 +1094,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;

--- a/regress_report.txt
+++ b/regress_report.txt
@@ -1,5 +1,5 @@
 ************ Regression Summary *************
-Sun 28 Jun 2026 08:09:09 PM PDT
+Mon 29 Jun 2026 11:52:15 AM PDT
 Line counts should be 0 for pass
 pint run ***************************************
 0 sample_programs/test_results/pint/hello.dif
@@ -127,7 +127,7 @@ network_test run
 
 Total differences: 0
 Fails: 0
-Sun 28 Jun 2026 08:14:30 PM PDT
+Mon 29 Jun 2026 11:58:05 AM PDT
 Files sha256sum ***************************************
 Source files
 9e6bc2bc0202ff3f2d0f2908311b4351171949eafc2e7cda51a89ee9dbab5d0d  -


### PR DESCRIPTION
## Summary

Clears the nine `'w' unreferenced` warnings from building `libs/tests/graphics_test`.

The filled-shape speed benchmarks — `frectspeed`, `frrectspeed`, `fellipsespeed`, `farcspeed`, `fchordspeed`, `ftrianglespeed`, `ftextspeed`, `fpictspeed`, `fpictnsspeed` — take a `w` (line width) parameter only so their signature matches the procedure parameter `benchtest(procedure fp(w, t: integer; var s: integer); …)` requires. Filled shapes have no line width (unlike the outline versions, which call `linewidth(output, w)`), so `w` is genuinely unused there and can't be removed.

Marked each with `refer(w)`, placed right after `begin` — before the timed loop, so it can't affect the benchmark timings.

## Validation

- `pc libs/tests/graphics_test -r`: **0 unreferenced, 0 errors**.
- All other `libs/tests` programs were already clean (checked).

Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
