### PR TITLE
graphics_test: refer() unused w in filled-shape speed tests

### DIFF
--- a/libs/tests/graphics_test.pas
+++ b/libs/tests/graphics_test.pas
@@ -740,6 +740,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;
@@ -771,6 +772,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;
@@ -835,6 +837,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;
@@ -907,6 +910,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;
@@ -946,6 +950,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;
@@ -984,6 +989,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;
@@ -1016,6 +1022,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;
@@ -1053,6 +1060,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;
@@ -1086,6 +1094,7 @@ var
 
 begin
 
+   refer(w); { unused by filled shapes; required by the benchtest fp signature }
    auto(output, false);
    curvis(output, false);
    page;


### PR DESCRIPTION
## Summary

Clears the nine `'w' unreferenced` warnings from building `libs/tests/graphics_test`.

The filled-shape speed benchmarks (`frectspeed`, `frrectspeed`, `fellipsespeed`, `farcspeed`, `fchordspeed`, `ftrianglespeed`, `ftextspeed`, `fpictspeed`, `fpictnsspeed`) take a `w` (line width) parameter only so their signature matches what `benchtest` requires; filled shapes have no line width, so `w` is unused and can't be removed. Marked each with `refer(w)`, placed after `begin` (before the timed loop, so it can't affect benchmark timings).

Validated: `pc libs/tests/graphics_test -r` → 0 unreferenced, 0 errors; siblings already clean. Test-only.

(Supersedes #491, which was auto-closed when its branch was inadvertently deleted; this branch drops a stray regression-report commit that conflicted with master.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
