### PR TITLE
create_user: ship the graph_games .pas sources as examples

### DIFF
--- a/bin/create_user
+++ b/bin/create_user
@@ -51,6 +51,12 @@ cp build/pgen/psystem_stdio.o "$root/build/pgen/"
 cp setpath "$root/"
 for d in LICENSE README INSTALL; do [ -f "$d" ] && cp "$d" "$root/"; done
 
+# Example game sources (Pascaline graphics/sound demos). Sources only; the games
+# that load assets (chess, conquest, backgammon) also need their data files
+# (graph_games/chess_pieces, conquest_map.bmp, dice.wav, slide.wav), not shipped.
+mkdir -p "$root/graph_games"
+cp graph_games/*.pas "$root/graph_games/"
+
 tar czf user.tgz -C "$stage" pascal-p6
 rm -rf "$stage"
 echo "created user.tgz ($(du -h user.tgz | cut -f1))"


### PR DESCRIPTION
## Summary

Adds the seven Pascaline graphics/sound game sources to `user.tgz` under `graph_games/`, as compilable examples: `backgammon`, `breakout`, `checkers`, `chess`, `conquest`, `defenders`, `pong`.

## Note

Sources only, per request. The asset-loading games (`chess`, `conquest`, `backgammon`) also need their data files to run — `graph_games/chess_pieces/`, `conquest_map.bmp`, `dice.wav`, `slide.wav` — which are **not** shipped. `breakout`/`checkers`/`defenders`/`pong` have no asset dependency.

Verified: after `create_user`, all seven `.pas` appear under `pascal-p6/graph_games/` in the tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)