### PR TITLE
Website: deploy docs/ to Pages via Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,48 @@
+#
+# Deploy the project website (docs/) to GitHub Pages.
+#
+# The repo is far too large for the legacy Pages pipeline (it clones the whole
+# repository, submodule included, and times out), so the site deploys through
+# the Actions Pages flow instead: sparse-checkout just docs/ and upload it as
+# the Pages artifact. docs/ holds index.html plus published copies of what it
+# links (see bin/webupdate).
+#
+name: Deploy website
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout docs only
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: docs
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Every legacy Pages build now errors regardless of source folder (it clones the whole ~1GB repo + submodule before publishing, and this repo outgrew it) — the live site is stuck on a stale build, so neither the sample gallery (#509/#510) nor anything else can ship. Replace it with the Actions Pages flow: sparse-checkout of `docs/` only, uploaded as the Pages artifact. Triggers on pushes touching `docs/` or manually. Pages `build_type` flips to `workflow` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)