### PR TITLE
Website: annotate the .nojekyll marker (force full redeploy)

### DIFF
--- a/docs/.nojekyll
+++ b/docs/.nojekyll
@@ -1,0 +1,1 @@
+# Pages marker: serve this folder as static files (no Jekyll). Content of this file is irrelevant.


### PR DESCRIPTION
The first Actions Pages deployment was canceled mid-propagation (status-poll timeout while the deployment queue was congested), leaving the origin partially populated — the pasdoc-generated pages (pc/*.html, sample_programs/hello.html, utils/pasdoc.html, source/pcom.html) 404 while the rest serves. Content-identical redeploys get deduplicated against that broken deployment ID, so this changes the docs/ tree hash (a comment in the .nojekyll marker) to force a fresh full deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)