### PR TITLE
Website: never let the Pages deploy step time out

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,3 +46,11 @@ jobs:
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          # Status reporting on this site can lag far behind the actual
+          # propagation. Do NOT let the action time out: on timeout it cancels
+          # the deployment server-side, which both breaks the deploy and
+          # poisons that content hash (identical re-deploys are deduplicated
+          # against the cancelled one).
+          timeout: 1800000
+          error_count: 30

--- a/docs/.nojekyll
+++ b/docs/.nojekyll
@@ -1,1 +1,1 @@
-# Pages marker: serve this folder as static files (no Jekyll). Content of this file is irrelevant.
+# Pages marker: serve this folder as static files (no Jekyll). File content is not used (2026-07-02T16:47:30Z).


### PR DESCRIPTION
deploy-pages status polling lags behind actual propagation on this site; on timeout the action **cancels the deployment server-side**, which breaks the deploy and poisons that content hash (identical redeploys get deduplicated against the cancelled deployment). This raises the deploy step timeout to 30 min + tolerated error count, and stamps the marker file for a virgin content hash. Combined with the Pages site reset (disable/re-enable to clear the wedged legacy 'errored' state), this should produce the first fully green deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)