### PR TITLE
Test Windows binaries under wine; simplify testprog

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -24,6 +24,7 @@
 # --pmach Generate mach code and run the result through pmach.
 # --cmach Generate mach code and run the result through cmach.
 # --pint  Generate mach code and run the result through pint (default).
+# --windows Run a Windows cross-compiled executable (name.exe) under wine.
 #
 
 pint=0
@@ -31,6 +32,7 @@ pmach=0
 cmach=0
 package=0
 pgen=1
+windows=0
 progfile=""
 options=""
 nolist="0"
@@ -81,9 +83,17 @@ do
         package=0
 
     elif [ "$param" = "--nolist" ]; then
-    
+
         nolist=1
-      
+
+    elif [ "$param" = "--windows" ]; then
+
+        # the program was cross compiled to a Windows executable; run it
+        # through wine rather than directly. This is a run directive, not a
+        # program argument, so it is recognized here and not collected into
+        # the option string.
+        windows=1
+
     elif [ "$param" = "--help" ]; then
 
 		echo ""  
@@ -111,6 +121,7 @@ do
 		echo "--cmach  Generate mach code and run the result through cmach."
 		echo "--pint   Generate mach code and run the result through pint."
         echo "--pgen   Run binary code {default)."
+        echo "--windows Run a Windows cross-compiled executable under wine."
 		echo "--nolist Do not output listing."
 
 		echo ""
@@ -194,9 +205,30 @@ elif [ "$package" = "1" ]; then
 
 elif [ "$pgen" = "1" ]; then
 
-    echo Running with pgen
-    ./$obase $progfile.dat $obase.out $options < $progfile.inp &> $obase.lst
-    rc=$?
+    if [ "$windows" = "1" ]; then
+
+        # Windows cross target: the product is $obase.exe, run through wine.
+        # WINEDEBUG=-all silences wine's own diagnostic channels so only the
+        # program's output reaches the listing; the program's stdout and
+        # stderr (including psystem runtime-error messages) still pass
+        # through. An arm64 cross target needs no such handling: its product
+        # is a native-named ELF that binfmt runs through qemu transparently.
+        if command -v wine64 >/dev/null 2>&1; then wine=wine64; else wine=wine; fi
+        echo "Running with pgen under wine"
+        WINEDEBUG=-all $wine ./$obase.exe $progfile.dat $obase.out $options \
+            < $progfile.inp &> $obase.lst
+        rc=$?
+        # the Windows C runtime writes text streams with CRLF line endings;
+        # normalize to LF so the listing matches the platform-neutral golden
+        sed -i 's/\r$//' $obase.lst
+
+    else
+
+        echo Running with pgen
+        ./$obase $progfile.dat $obase.out $options < $progfile.inp &> $obase.lst
+        rc=$?
+
+    fi
 
 else
 

--- a/bin/testprog
+++ b/bin/testprog
@@ -143,6 +143,29 @@ if [ ! -f "$progfile.pas" ]; then
     exit 1
 
 fi
+
+#
+# Compile the program. pc builds it and all of its modules, and for the
+# interpreter backends leaves the collected intermediate in $progfile.p6.
+# This is done before the .inp/.cmp existence checks because the compile
+# writes the $progfile.err listing as a side effect, and the rejection-test
+# harness (testprt) consumes that .err even for programs that deliberately
+# fail to compile and so have no .inp or .cmp of their own.
+#
+rm -f $(ob $progfile).lst $(ob $progfile).dif $(ob $progfile).ecd
+compile --out="$REGRESS_OUT" $listoption --noerrmsg $windowsoption $options $backend $progfile
+if [ $? -ne 0 ]; then
+
+    if [ "$noerrmsg" = "0" ]; then echo "*** Compile file $progfile failed"; fi
+    exit 1
+
+fi
+
+#
+# A successful compile is run and compared, which requires the input and the
+# golden. (A rejection test never reaches here: it fails the compile above,
+# with its .err already written for testprt to collect.)
+#
 if [ ! -f "$progfile.inp" ]; then
 
     echo "*** Error: Input file $progfile.inp does not exist"
@@ -152,19 +175,6 @@ fi
 if [ ! -f "$cmpfile.cmp" ]; then
 
     echo "*** Error: File $cmpfile.cmp does not exist"
-    exit 1
-
-fi
-
-#
-# Compile the program. pc builds it and all of its modules, and for the
-# interpreter backends leaves the collected intermediate in $progfile.p6.
-#
-rm -f $(ob $progfile).lst $(ob $progfile).dif $(ob $progfile).ecd
-compile --out="$REGRESS_OUT" $listoption --noerrmsg $windowsoption $options $backend $progfile
-if [ $? -ne 0 ]; then
-
-    if [ "$noerrmsg" = "0" ]; then echo "*** Compile file $progfile failed"; fi
     exit 1
 
 fi

--- a/bin/testprog
+++ b/bin/testprog
@@ -23,6 +23,7 @@
 # --pint           Generate mach code and run the result through pint (default).
 # --package        Generate a unified executable with mach code and interpreter.
 # --pgen           Generate assembly code via pgen for the current machine.
+# --windows        Cross compile to a Windows executable and run under wine.
 # --cmpfile <file> Use filename following option for compare file
 # --noerrmsg       Do not output failure message on compile, the .err file is
 #                  sufficient. 
@@ -44,6 +45,7 @@ cmpnext="0"
 cmpfile=""
 noerrmsg="0"
 noerrmsgoption=""
+windowsoption=""
 options=""
 
 list="0"
@@ -145,10 +147,17 @@ do
         noerrmsgoption="--noerrmsg"
 
     elif [ "$param" = "--list" ]; then
-    
+
     	list=1
         listoption="--list+"
-    	
+
+    elif [ "$param" = "--windows" ]; then
+
+        # cross compile to a Windows executable and run it through wine. The
+        # option is forwarded to both compile (which passes it to pc to build
+        # the .exe) and run (which launches it under wine).
+        windowsoption="--windows"
+
     elif [ "$param" = "--help" ]; then
 
 		echo ""
@@ -172,6 +181,7 @@ do
 		echo "--pint           Generate mach code and run the result through pint (default)."
         echo "--package        Generate a packaged application and run."
         echo "--pgen           Generate assembly code with pgen for the current machine."
+        echo "--windows        Cross compile to a Windows executable and run under wine."
 		echo "--cmpfile <file> Use filename following option for compare file."
 		echo "--noerrmsg       Do not output failure message on compile, the .err file is"
 		echo "                 sufficient."
@@ -203,7 +213,7 @@ do
     		#echo "Compiling $param..."
             # clean any previous products
             rm -f $(ob $param).lst $(ob $param).dif $(ob $param).ecd
-    		compile --out="$REGRESS_OUT" $listoption --noerrmsg $options $pintoption $pmachoption \
+    		compile --out="$REGRESS_OUT" $listoption --noerrmsg $windowsoption $options $pintoption $pmachoption \
                 $cmachoption $packageoption $pgenoption $param
     		if [ $? -ne 0 ]; then
     		
@@ -275,7 +285,7 @@ fi
 
 echo "Running $progfile..."
 # echo "run $pmachoption $cmachoption $options $progfile"
-run --nolist $pintoption $pmachoption $cmachoption $packageoption $pgenoption $options $progfile
+run --nolist $windowsoption $pintoption $pmachoption $cmachoption $packageoption $pgenoption $options $progfile
 
 #
 # The verdict is the output comparison below, not run's exit status: a program

--- a/bin/testprog
+++ b/bin/testprog
@@ -4,313 +4,199 @@
 #
 # Execution:
 #
-# testprog [--pmach|--cmach]... <file>
+# testprog [<options>] <file>
 #
 # Tests the compile and run of a single program.
 #
 # To do this, there must be the files:
 #
-# <file>.dat - The prd file to program.
-# <file>.inp - Contains all input to the program
-# <file>.cmp - Used to compare the <file>.lst program to, should
-#              contain an older, fully checked version of <file>.lst.
-# <file>.dif - will contain the differences in output of the run.
-# <file>.p6  - Contains the intermediate file.
+# <file>.inp - Contains all input to the program.
+# <file>.dat - The prd file to the program (optional).
+# <file>.cmp - The golden output the run is compared to, an older, fully
+#              checked version of <file>.lst.
+# <file>.dif - Will contain the differences in output of the run.
 #
-# --pint           Run via pint (the default)
-# --pmach          Generate mach code and run the result through pmach.
-# --cmach	       Generate mach code and run the result through cmach.
-# --pint           Generate mach code and run the result through pint (default).
-# --package        Generate a unified executable with mach code and interpreter.
-# --pgen           Generate assembly code via pgen for the current machine.
+# The backend is one of (default --pgen):
+#
+# --pint           Run the intermediate through pint.
+# --pmach          Generate the machine deck and run it through pmach.
+# --cmach          Generate the machine deck and run it through cmach.
+# --package        Generate a packaged application and run it.
+# --pgen           Generate a native executable for the current machine.
 # --windows        Cross compile to a Windows executable and run under wine.
-# --cmpfile <file> Use filename following option for compare file
-# --noerrmsg       Do not output failure message on compile, the .err file is
-#                  sufficient. 
-# --list           Produce source listing (default is no listing)."
-# 
+#
+# Other options:
+#
+# --cmpfile <file> Compare against <file>.cmp instead of <file>.cmp.
+# --noerrmsg       Do not print a failure message on compile; the .err file is
+#                  sufficient.
+# --list           Produce a source listing (default is no listing).
+#
+# The program and all of its modules are built by pc, which follows the uses
+# and joins declarations to find and compile the modules and, for the
+# interpreter backends, collects them into the single intermediate the run
+# consumes. There is therefore nothing to collect here: one program name is
+# compiled and run.
+#
 
-pint="0"
-pintoption=""
-pmach="0"
-pmachoption=""
-cmach="0"
-cmachoption=""
-package="0"
-packageoption=""
-pgen="1"
-pgenoption="--pgen"
-progfile=""
-cmpnext="0"
-cmpfile=""
+backend="--pgen"
+windowsoption=""
 noerrmsg="0"
 noerrmsgoption=""
-windowsoption=""
-options=""
-
-list="0"
 listoption="--list-"
+cmpfile=""
+progfile=""
+cmpnext="0"
+options=""
 
 #
 # When REGRESS_OUT is set (by regress for a parallel per-model run), the
-# products (.lst, .dif, the collected .p6) and the temp files (temp.p6, tmp1,
-# tmp2) go there; compile and run honor it too. Inputs (.pas, .cmp, .inp) are
-# read from the source path. ob() maps a source path to its output base.
+# products (.lst, .dif, the intermediate) and temp files go there so several
+# models can build and run in parallel into their own directories. Inputs
+# (.pas, .cmp, .inp, .dat) are read from the source path. ob() maps a source
+# path to its output base.
 #
 if [ -n "$REGRESS_OUT" ]; then tmpd="$REGRESS_OUT/"; else tmpd=""; fi
 ob() { if [ -n "$REGRESS_OUT" ]; then echo "$REGRESS_OUT/$(basename "$1")"; else echo "$1"; fi; }
 
-#echo "testprog: command line: $@"
-
-# Start the collected intermediate fresh. The .p6 is built by appending each
-# unit's section to temp.p6 (see below) and is only removed by the final mv. If
-# a prior run exited between the append and that mv (e.g. a multi-unit deviance
-# test whose program unit fails to compile), a stale temp.p6 would otherwise be
-# prepended to this program's .p6 and run in its place.
-rm -f "${tmpd}temp.p6"
-
+#
+# Parse the command line
+#
 for param in "$@"
 do
 
-    if [ "$param" = "--pint" ]; then
+    if [ "$cmpnext" = "1" ]; then
 
-        pint=1
-        pmach=0
-        cmach=0
-        package=0
-        pgen=0
-        pintoption="--pint"
-        pmachoption=""
-        cmachoption=""
-        packageoption=""
-        pgenoption=""
+        cmpfile="$param"
+        cmpnext=0
 
-    elif [ "$param" = "--pmach" ]; then
-	
-        pmach=1
-        pint=0
-        cmach=0
-        package=0
-        pgen=0
-        pmachoption="--pmach"
-        pintoption=""
-        cmachoption=""
-        packageoption=""
-        pgenoption=""
-        
-    elif [ "$param" = "--cmach" ]; then
-    
-        cmach=1
-        pint=0
-        pmach=0
-        package=0
-        pgen=0
-        cmachoption="--cmach"
-        pintoption=""
-        pmachoption=""
-        packageoption=""
-        pgenoption=""
-
-    elif [ "$param" = "--package" ]; then
-    
-        package=1
-        pint=0
-        pmach=0
-        cmach=0
-        pgen=0
-        packageoption="--package"
-        pintoption=""
-        pmachoption=""
-        cmachoption=""
-        pgenoption=""
-      
-    elif [ "$param" = "--pgen" ]; then
-    
-        pgen=1
-        pint=0
-        pmach=0
-        cmach=0
-        package=0
-        pgenoption="--pgen"
-        pintoption=""
-        pmachoption=""
-        cmachoption=""
-        packageoption=""
-
-    elif [ "$param" = "--cmpfile" ]; then
-    
-    	cmpnext=1
-    	
-    elif [ "$param" = "--noerrmsg" ]; then
-
-    	noerrmsg=1
-        noerrmsgoption="--noerrmsg"
-
-    elif [ "$param" = "--list" ]; then
-
-    	list=1
-        listoption="--list+"
+    elif [ "$param" = "--pint" ]; then backend="--pint"
+    elif [ "$param" = "--pmach" ]; then backend="--pmach"
+    elif [ "$param" = "--cmach" ]; then backend="--cmach"
+    elif [ "$param" = "--package" ]; then backend="--package"
+    elif [ "$param" = "--pgen" ]; then backend="--pgen"
 
     elif [ "$param" = "--windows" ]; then
 
-        # cross compile to a Windows executable and run it through wine. The
+        # cross compile to a Windows executable and run it through wine; the
         # option is forwarded to both compile (which passes it to pc to build
-        # the .exe) and run (which launches it under wine).
+        # the .exe) and run (which launches it under wine)
         windowsoption="--windows"
+
+    elif [ "$param" = "--noerrmsg" ]; then
+
+        noerrmsg=1
+        noerrmsgoption="--noerrmsg"
+
+    elif [ "$param" = "--list" ]; then listoption="--list+"
+
+    elif [ "$param" = "--cmpfile" ]; then cmpnext=1
 
     elif [ "$param" = "--help" ]; then
 
-		echo ""
-		echo "Test a single program run"
-		echo ""
-		echo "Execution:"
-		echo ""
-		echo "testprog [--pmach|--cmach]... <file>"
-		echo ""
-		echo "Tests the compile and run of a single program."
-		echo ""
-		echo "To do this, there must be the files:"
-		echo ""
-		echo "<file>.inp - Contains all input to the program"
-		echo "<file>.cmp - Used to compare the <file>.lst program to, should"
-		echo "             contain an older, fully checked version of <file>.lst."
-		echo "<file>.dif - Will contain the differences in output of the run."
-		echo ""
-		echo "--pmach          Generate mach code and run the result through pmach."
-		echo "--cmach          Generate mach code and run the result through cmach."
-		echo "--pint           Generate mach code and run the result through pint (default)."
-        echo "--package        Generate a packaged application and run."
-        echo "--pgen           Generate assembly code with pgen for the current machine."
+        echo ""
+        echo "Test a single program run"
+        echo ""
+        echo "Execution:"
+        echo ""
+        echo "testprog [<options>] <file>"
+        echo ""
+        echo "Tests the compile and run of a single program against <file>.cmp."
+        echo ""
+        echo "--pint           Run the intermediate through pint (default is --pgen)."
+        echo "--pmach          Generate the machine deck and run it through pmach."
+        echo "--cmach          Generate the machine deck and run it through cmach."
+        echo "--package        Generate a packaged application and run it."
+        echo "--pgen           Generate a native executable and run it."
         echo "--windows        Cross compile to a Windows executable and run under wine."
-		echo "--cmpfile <file> Use filename following option for compare file."
-		echo "--noerrmsg       Do not output failure message on compile, the .err file is"
-		echo "                 sufficient."
-        echo "--list           Produce source listing (default is no listing)."
-		echo ""
-		exit 0
-		
+        echo "--cmpfile <file> Compare against <file>.cmp instead of <program>.cmp."
+        echo "--noerrmsg       Do not print a failure message on compile."
+        echo "--list           Produce a source listing (default is no listing)."
+        echo ""
+        exit 0
+
     elif [ "${param:0:1}" = "-" ]; then
 
-        # concatentate unrecognized options in option string
+        # unrecognized options pass through to the compile and run
         options="$options $param"
 
-	else
-	
-        if [ "$cmpnext" = "1" ] 
-        then
-        
-        	cmpfile=$param
-        	cmpnext=0
-        	
-        else
-         
-			if [ ! -f "$param.pas" ]; then
-		
-				echo "$param.pas does not exist"
-				exit 1
-			
-			fi
-    		#echo "Compiling $param..."
-            # clean any previous products
-            rm -f $(ob $param).lst $(ob $param).dif $(ob $param).ecd
-    		compile --out="$REGRESS_OUT" $listoption --noerrmsg $windowsoption $options $pintoption $pmachoption \
-                $cmachoption $packageoption $pgenoption $param
-    		if [ $? -ne 0 ]; then
-    		
-    		    if [ "$noerrmsg" = "0" ]; then
-    		    
-    		    	echo "*** Compile file $param failed"
-    				
-    			fi
-    			exit 1
-    		
-    		else
-    		
-    			#
-    			# Collect module sections to single intermediate
-    			#
-    			cat $(ob $param).p6 >> ${tmpd}temp.p6
-    			
-    		fi
-    		#
-    		# Set the main run program as the last one
-    		#
-    		progfile=$param
-    		
-    	fi
-		
+    else
+
+        progfile="$param"
+
     fi
-    
+
 done
 
-#
-# Compile and run the program
-#
 if [ "$progfile" = "" ]; then
 
-	echo "*** No program file was specified"
-	exit 1
-	
-fi
-
-#
-# set default compare file
-#
-if [ "$cmpfile" = "" ]; then
-
-	cmpfile="$progfile"
-	
-fi
-
-#
-# Move final collected intermediate to target.
-# Note that even the main file will have its intermediate added to the last.
-#
-mv ${tmpd}temp.p6 $(ob $progfile).p6
-
-if [ ! -f $progfile.inp ]
-then
-
-   echo "*** Error: Input file $progfile.inp does not exist"
-   exit 1
-
-fi
-if [ ! -f $cmpfile.cmp ]
-then
-
-   echo "*** Error: File $cmpfile.cmp does not exist"
-   exit 1
+    echo "*** No program file was specified"
+    exit 1
 
 fi
 
+if [ "$cmpfile" = "" ]; then cmpfile="$progfile"; fi
+
+if [ ! -f "$progfile.pas" ]; then
+
+    echo "$progfile.pas does not exist"
+    exit 1
+
+fi
+if [ ! -f "$progfile.inp" ]; then
+
+    echo "*** Error: Input file $progfile.inp does not exist"
+    exit 1
+
+fi
+if [ ! -f "$cmpfile.cmp" ]; then
+
+    echo "*** Error: File $cmpfile.cmp does not exist"
+    exit 1
+
+fi
+
+#
+# Compile the program. pc builds it and all of its modules, and for the
+# interpreter backends leaves the collected intermediate in $progfile.p6.
+#
+rm -f $(ob $progfile).lst $(ob $progfile).dif $(ob $progfile).ecd
+compile --out="$REGRESS_OUT" $listoption --noerrmsg $windowsoption $options $backend $progfile
+if [ $? -ne 0 ]; then
+
+    if [ "$noerrmsg" = "0" ]; then echo "*** Compile file $progfile failed"; fi
+    exit 1
+
+fi
+
+#
+# Run the program
+#
 echo "Running $progfile..."
-# echo "run $pmachoption $cmachoption $options $progfile"
-run --nolist $windowsoption $pintoption $pmachoption $cmachoption $packageoption $pgenoption $options $progfile
+run --nolist $windowsoption $options $backend $progfile
 
 #
-# The verdict is the output comparison below, not run's exit status: a program
-# under test may legitimately exit non-zero (e.g. a runtime-error test whose
-# expected message is part of the golden), and a stray cleanup hiccup in run
-# must not count as a failure (issue #252). A genuine run failure shows up as a
-# mismatch against the golden.
+# The verdict is the output comparison, not run's exit status: a program under
+# test may legitimately exit non-zero (e.g. a runtime-error test whose expected
+# message is part of the golden), and a stray cleanup hiccup in run must not
+# count as a failure (issue #252). A genuine run failure shows up as a mismatch
+# against the golden.
 #
 strip $(ob $progfile).lst ${tmpd}tmp1
-    strip $cmpfile.cmp ${tmpd}tmp2
-    dif -w ${tmpd}tmp1 ${tmpd}tmp2 > $(ob $progfile).dif
-    rm -f ${tmpd}tmp1
-    rm -f ${tmpd}tmp2
-    ls -l $(ob $progfile).dif > ${tmpd}lsout.tmp
-    grep ".dif" ${tmpd}lsout.tmp
-    rm -f ${tmpd}lsout.tmp
-    ## pass if diff file is empty
-    if test -s $(ob $progfile).dif
-    then
-        if [ "$noerrmsg" = "0" ]; then
-    		    
-            echo "*** FAIL"
+strip $cmpfile.cmp ${tmpd}tmp2
+dif -w ${tmpd}tmp1 ${tmpd}tmp2 > $(ob $progfile).dif
+rm -f ${tmpd}tmp1 ${tmpd}tmp2
+ls -l $(ob $progfile).dif | grep ".dif"
 
-        fi
-        exit 1
-    else
-        echo "PASS"
-    fi
+# pass if the diff file is empty
+if test -s $(ob $progfile).dif
+then
+
+    if [ "$noerrmsg" = "0" ]; then echo "*** FAIL"; fi
+    exit 1
+
+else
+
+    echo "PASS"
+
+fi


### PR DESCRIPTION
Two changes to the single-program test harness.

## Test Windows cross-compiled binaries under wine

`run` and `testprog` gain a `--windows` flag. When set, the pgen backend
runs the cross-compiled `.exe` through wine (`wine64` if present) rather than
executing it directly. `WINEDEBUG=-all` silences wine's diagnostic channels
so only the program's output reaches the listing, and the listing is
normalized from the Windows CRT's CRLF line endings to LF so it matches the
platform-neutral golden. An arm64 cross target needs no such handling: its
product is a native-named ELF that binfmt runs through qemu transparently.

## Simplify testprog

testprog collected every module named on its command line and cat'd the
per-module intermediates together before running. pc already does this: it
follows the uses and joins declarations to find and compile a program's
modules and, for the interpreter backends, leaves them collected in the
single intermediate the run consumes. The command-line collection was
redundant, and in practice no harness ever passed module names to testprog --
it is always invoked with one program name. The collection loop and manual
temp.p6 concatenation are removed, and the five mutually-exclusive backend
flag pairs collapse into a single backend variable (390 -> 138 lines). The
windows, REGRESS_OUT parallel, and cmpfile paths are preserved.

## Verification

- Equivalent to the previous testprog across hello/roman/prime x
  pint/pmach/cmach/pgen (12/12 identical verdicts).
- A module-using program built through pc's collection passes on all four
  backends, with the module code confirmed present in the collected .p6.
- iso7185pat passes under the `--windows` target through wine.