### PR TITLE
Fix win64 native execution: wrapper LLP64 types, universal line endings, ';' module path separator

### DIFF
--- a/WIN64_BRINGUP_FINDINGS.md
+++ b/WIN64_BRINGUP_FINDINGS.md
@@ -1,0 +1,174 @@
+# Win64 native bring-up findings
+
+Handoff notes from the Windows-side debugging session (2026-07-15) that produced
+PR #538 (`win64-modpath-llp64-eoln-fixes`). Written for whoever (human or
+Claude) continues the work on the Linux side. The machine used was Scott's
+Windows 10 box, msys64/mingw64 gcc 15.2, repo at `C:\projects\PASCAL\pascal-p6`.
+
+The starting symptom: `pc hello` on native Windows printed a cascade of
+`Invalid command` errors against `bin/pc.ins` and then `*** pc: Error: System
+fault`. Three independent root causes were found. All Windows host executables
+in the hosts tree are affected and need a cross-rebuild from these sources.
+
+## Root cause 1: LLP64 in the Pascaline/C binding layer
+
+`libs/source` (support.h, services_wrapper.h/.c, and the graphics/terminal/
+network wrappers) was written assuming `long` is 64 bits. True on LP64 Linux;
+on win64 (LLP64, mingw) `long` is 32 bits. Every struct shared between the C
+wrappers and compiled Pascal then has the wrong layout on Windows:
+
+- `filrec` (services_wrapper.h): C builds a 112-byte struct with `next` at
+  offset 104; the Pascal side reads the Pascaline layout — 192 bytes, `next`
+  at offset 184 (integer = 64 bits, sets = 256 bits). Pascal reads 80 bytes
+  past the end of the C allocation. `pc` faulted in `dolist` ("System fault",
+  `l^.next` garbage non-nil); pgen segfaulted; pint's extlink threw
+  "Value out of range"; the shipped cmach.exe segfaulted.
+- `pstring_header.len` (support.h): 4-byte len written, 8-byte len read.
+- `PEVTL` event macro: casts to `long*` while the comment says 8 bytes.
+
+**Why the wine regression never caught it:** wine's heap happened to hold
+zeros past the allocation, so the garbage `next` read back as nil. Native
+Windows heaps don't.
+
+**Fix (in the PR):** per Scott, do NOT change declarations to `long long`
+(that would break future 32-bit targets). psystem.c already established the
+convention: `#define long long long` under `_WIN32`, after all system
+includes. The same block is now in `support.h`, positioned so that CRT
+prototypes and the Ami headers (`services.h` etc., included before support.h
+in every binding source) keep their true `long`. This fixes services,
+graphics, terminal and sound wrappers wholesale on rebuild. Note
+`filrec.size/alloc` had literal `long long`, which the macro would expand to
+`long long long long` (a hard error) — they are now plain `long`.
+
+**Verified:** rebuilt win64 `services.a` natively; a Pascal test program
+calling `services.list('*.p6')` and printing `l^.name^` runs correctly
+(crashes with the old library). The pc scanner stack (scanner/restbl/spctbl/
+tolkens/strings) also verified working.
+
+## Root cause 2: line endings
+
+`bin/pc.ins` checked out CRLF (`core.autocrlf=true`), and the parse module saw
+the `\r` before each newline as a stray character — every error column in the
+original spew pointed exactly one past the last real character. The same
+problem applies to any text file the tools read (decks written by pcom on
+Windows are CRLF too, via mingw text-mode stdio).
+
+**Fix (in the PR), per Scott:** never convert files; recognize endings
+universally in the runtime. `source/pgen/psystem.c` now implements the
+flip.c / IP Pascal algorithm: two per-file flags (`filecr[]`, `filelf[]`
+beside `fileoln[]`) set on the current character being cr/lf before the next
+is read; an lf directly after cr (or cr after lf) is the second half of the
+same line ending and is skipped. Endings crlf, lfcr, cr, lf are all valid.
+Consumption goes through `getcunv()`, peeks through `chkcunv()` (both new);
+`eoffile/eolnfile/chkfile/getfneoln` route through them and now take the
+logical file number. Binary reads are untouched. The flags reset at
+`resetfn` and the attach path.
+
+**Note:** pint.pas and cmach.c have their own deck readers; they coped with
+CRLF decks in testing, but were not audited for the same tolerance.
+
+## Root cause 3: module path separator vs drive letters
+
+pc concatenates its module path with `:` and splits it with
+`indexp(pt, ':')`. On Windows the components themselves contain `:`
+(`C:\...`), so the first split yields a bare `C`; `fndfil`/`makpth` then built
+`C\psystem.pas`, `ami_fulnam` → `SetCurrentDirectory("C\")` failed, and
+`winerr()` exited with status 1 — **silently**, because its stderr message is
+lost when output is piped. Found with gdb (`b exit`, backtrace through
+`pc.fndfil → makpth → wrapper_fulnam("C\psystem.pas") → ami_setcur("C\") →
+winerr`).
+
+**Fix (in the PR), per Scott's decision:** `;` is Pascal-P6's path-list
+separator **on all hosts** — not per-host switching, which would create
+linux/windows misunderstandings. These concatenated strings are internal to
+the toolset. All seven build/split sites in pc.pas now use `;`.
+
+**Migration:** `MODULEPATH` environment variables written `a:b` must become
+`a;b` (quote it in a Unix shell). Docs still describe the path as
+`:`-separated (docs/pc, and the `usespath` comment block in pc.pas ~line
+2863) — not yet updated.
+
+## What the Linux side should do
+
+1. `git checkout win64-modpath-llp64-eoln-fixes` (PR #538).
+2. Cross-rebuild the win64 runtime libs (`libs/win64/*` targets → hosts tree)
+   and all Windows host executables (`bin/build` / `compwin` flow), then run
+   the regression under wine. Note wine's zeroed heap masks LLP64 layout bugs
+   — a native Windows smoke test of at least `pc hello` is the real proof.
+3. Update the docs for the `;` separator and migrate any MODULEPATH settings.
+4. The PR deliberately contains **no binaries**; the hosts tree binaries in
+   the repo are still the broken builds.
+
+## Known remaining issues (not fixed in the PR)
+
+- `network_support.c`: `(unsigned long long)` casts will expand badly under
+  the redefined `long` if that file ever includes support.h behind the macro
+  (currently it includes network.h only); its private
+  `typedef struct { long len; ... } pstrrec` still has 32-bit len on win64
+  unless compiled behind the macro. Needs the same include-order treatment.
+- `source/cmach/extern.inc` `putlongset(address, long v)` shifts `v` by up to
+  56 bits — UB/garbage for the high 4 set bytes when `long` is 32 bits. (The
+  file is generated by tools/extgen/gencexec.py; fix the generator.)
+- `winerr()` (amitk windows/services.c) exits after an fprintf(stderr) that
+  can vanish; consider fflush + routing through the normal error machinery.
+  The drive-letter failure was completely invisible because of this.
+- The committed win64 hosts `psystem.a` predated the bundled bypass-stdio
+  member (no `stdio_printf` etc.). Rebuilt during this session. Related: the
+  Ami bypass stdio omits `rename()` on Windows (relies on the CRT), but a
+  `-DSTDIO_BYPASS` consumer's `rename()` call is coined to `stdio_rename` —
+  cmach on Windows needs a shim (one exists in the session scratchpad).
+- pint's command line parsing consumes `<deck> [<outfile>]` and any options
+  adjacent to them, so an interpreted program cannot receive a leading option
+  argument; workaround below. cmach passes args cleanly but its VM faulted
+  "Value out of range [3777]" running the pgen deck where pint (with
+  `--chkundef-`) succeeded — undiagnosed, possibly a cmach check or VM bug
+  worth a look.
+- pgen requires `--win64` explicitly on its command line even when the input
+  deck carries `win64+` (deliberate per independent.pas:1965, but the error
+  surfaces only after preamble emission, and stdout buffering hides it if the
+  run dies).
+- DWARF debug info emitted by pgen uses 32-bit relocations that overflow at
+  static link (`relocation truncated to fit ... .debug_info`) with mingw
+  binutils when linking `-g3`; the win64 exes here were linked with debug
+  stripped. May affect the `pgen-dwarf-types` work.
+
+## Bootstrap technique used (reference)
+
+A working native pc.exe was produced on Windows without any working pc, pgen,
+pint-externals or cmach, by:
+
+1. Native `pcom.exe` works — compile every unit to a `.p6` deck (`--win64`).
+2. Run **pgen as an interpreted deck** under pint:
+   `pint --chkundef- pgen_all.p6 junk.out <input_lf.p6> --win64 <out.s>`
+   where `pgen_all.p6` = concatenated decks of strings, version, endian, mpb,
+   parcmd, registers, independent, pgen (strings must be included or the
+   loader fails "Module not present"; `junk.out` absorbs pint's own output
+   slot so the remaining args reach the interpreted pgen; `--win64` sits
+   between pgen's input and output filenames so pint doesn't eat it).
+   LF-convert decks first when the interpreter lacks the psystem eoln fix.
+3. `gcc -static -g3 -c` each generated `.s`; link
+   `main.o <objects leaves-first, program last> services.a psystem.a -lm
+   -lpthread -Wl,--stack,8388608`, matching pc's own dolink order.
+4. A fixed native cmach was also built directly from `source/cmach/cmach.c`
+   (pure C, `-DEXTERNALS -DSTDIO_BYPASS -I amitk/libc -I amitk/include`,
+   bypass stdio compiled `-DSTDIO_BYPASS`, plus a `stdio_rename` shim, link
+   services.a sound.a network.a, NOT psystem.a) — it validated the wrapper
+   fix by running `services.list` decks correctly.
+
+Interpreted pgen throughput: small modules take minutes; pc.pas took ~40 min;
+scanner ~40 min; restbl ~15 min. msys64 make invocation quirks on the Windows
+box: pass `OS=Windows_NT PASCALP6=<abs path> TMP= TEMP=` as make command-line
+variables (env doesn't propagate) and use absolute target paths.
+
+## State of the Windows working tree (not in the PR)
+
+On Scott's Windows box (branch `win64-modpath-llp64-eoln-fixes` checked out):
+rebuilt `hosts/windows/x86/bit64/libs/{services.a,psystem.a}` and
+`libs/win64/*` from the fixed sources; `bin/pc_fixed.exe` / `bin/pc_dbg.exe`
+are bootstrap builds that still predate the `;`-separator recompile (their
+regeneration was running in background when the session moved to Linux);
+`bin/pc.ins` converted to LF (harmless; redundant once the psystem fix is in
+the binaries); `amitk` submodule initialized fresh. Scratch pipeline artifacts
+live under the session scratchpad `pcbuild/` directory, including win64 decks
+for all pgen modules (`w64_*.p6`), ready to finish a native pgen if ever
+needed.

--- a/libs/source/services_wrapper.h
+++ b/libs/source/services_wrapper.h
@@ -28,8 +28,8 @@ typedef long set[4];
 typedef struct filrec {
 
     char*          name;    /* name of file (zero terminated) */
-    long long      size;    /* size of file */
-    long long      alloc;   /* allocation of file */
+    long           size;    /* size of file */
+    long           alloc;   /* allocation of file */
     set            attr;    /* attributes */
     long           create;  /* time of creation */
     long           modify;  /* time of last modification */

--- a/libs/source/support.h
+++ b/libs/source/support.h
@@ -23,6 +23,26 @@ extern "C" {
 
 #include <stdio.h>
 
+/*
+ * Windows x64 is LLP64: long is 32 bits, unlike every other 64 bit
+ * platform. The Pascaline-facing types below use long as the machine
+ * word/Pascal integer type, which scales with the target on all other
+ * systems (64 bits on LP64 systems, 32 bits on 32 bit targets). For
+ * Windows only, long is redefined to long long (64 bits), matching
+ * psystem.c. This must appear after all system includes and after the
+ * Ami model header (services.h, terminal.h, ...) so that the C library
+ * prototypes and the Ami structures keep their true types -- every
+ * binding source includes support.h last for this reason.
+ */
+#ifdef _WIN32
+#define long long long
+#define labs llabs
+#undef LONG_MAX
+#define LONG_MAX LLONG_MAX
+#undef LONG_MIN
+#define LONG_MIN LLONG_MIN
+#endif
+
 /* Pascaline string: passed as a char* followed by an int length. */
 typedef char* string;
 

--- a/libs/tests/strings_test.cmp
+++ b/libs/tests/strings_test.cmp
@@ -54,7 +54,7 @@ s/b 'is not              '
 45: 'hi hi hi ' s/b 'hi hi hi '
 46: 'hihihi              '
 s/b 'hihihi              '
-Now is the time false s/b Now is the time false
+Now is the time false s/b Now is the time false
 52: 'for all good men    ' false
 s/b 'for all good men    ' false
 53: '       123          '

--- a/pc/pc.pas
+++ b/pc/pc.pas
@@ -776,7 +776,7 @@ begin
       repeat { try path components }
 
          { extract a single path from the module path }
-         i := indexp(pt, ':'); { find location of path divider }
+         i := indexp(pt, ';'); { find location of path divider }
          if i = 0 then begin { only one path left, use the whole thing }
 
             copy(w, pt); { place }
@@ -848,7 +848,7 @@ begin
       repeat { try path components }
 
          { extract a single path from the module path }
-         i := indexp(pt, ':'); { find location of path divider }
+         i := indexp(pt, ';'); { find location of path divider }
          if i = 0 then begin { only one path left, use the whole thing }
 
             copy(w, pt); { place }
@@ -1996,7 +1996,7 @@ begin
          repeat { try path components }
 
             { extract a single path from the module path }
-            x := indexp(pt, ':'); { find location of path divider }
+            x := indexp(pt, ';'); { find location of path divider }
             if x = 0 then begin { only one path left, use the whole thing }
 
                copy(w, pt); { place }
@@ -2091,7 +2091,7 @@ begin
             repeat { try path components }
 
                { extract a single path from the module path }
-               x := indexp(pt, ':'); { find location of path divider }
+               x := indexp(pt, ';'); { find location of path divider }
                if x = 0 then begin { only one path left, use the whole thing }
 
                   copy(w, pt); { place }
@@ -2960,7 +2960,7 @@ begin
 
 end;
 
-{ clean ':' separated path for relative directories }
+{ clean ';' separated path for relative directories }
 
 procedure cleanpath(var pt: string);
 
@@ -2974,7 +2974,7 @@ begin
    repeat
 
       { extract a single path from the module path }
-      i := indexp(pt, ':'); { find location of path divider }
+      i := indexp(pt, ';'); { find location of path divider }
       if i = 0 then begin { only one path left, use the whole thing }
 
          copy(w, pt); { place }
@@ -2988,7 +2988,7 @@ begin
       end;
       services.fulnam(w);
       { add new path }
-      if ts[1] <> ' ' then cat(ts, ':');
+      if ts[1] <> ' ' then cat(ts, ';');
       cat(ts, w)
 
    until i = 0; { no more paths to extract }
@@ -3139,7 +3139,7 @@ begin
             if modpth[1] = ' ' then copy(modpth, fn) { just copy }
             else begin
 
-              cat(modpth, ':'); { separate paths }
+              cat(modpth, ';'); { separate paths }
               cat(modpth, fn) { add new paths }
 
             end

--- a/source/cmach/cmach.c
+++ b/source/cmach/cmach.c
@@ -701,6 +701,8 @@ boolean filanamtab[MAXFIL+1]; /* name has been assigned flags */
 filsts filstate[MAXFIL+1]; /* file state holding */
 boolean filbuff[MAXFIL+1]; /* file buffer full status */
 boolean fileoln[MAXFIL+1]; /* last file character read was eoln */
+boolean filecr[MAXFIL+1];  /* last file character read was cr */
+boolean filelf[MAXFIL+1];  /* last file character read was lf */
 boolean filbof[MAXFIL+1]; /* beginning of file */
 varptr varlst; /* active var block pushdown stack */
 varptr varfre; /* free var block entries */
@@ -1740,17 +1742,59 @@ boolean isfree(address blk)
 
 /* system routine call */
 
-boolean eoffile(FILE* fp)
-{ long c; c = fgetc(fp); if (c != EOF) ungetc(c, fp); return (c == EOF); }
-
-boolean eolnfile(FILE* fp)
-{ long c; c = fgetc(fp); if (c != EOF) ungetc(c, fp); return (c == '\n'); }
-
-char chkfile(FILE* fp)
+/* Get next character with universal line ending recognition. Recognizes any of
+   the line ending forms crlf, lfcr, cr or lf as valid (the flip.c/IP Pascal
+   algorithm). Two flags are kept per file, set on the current character being
+   cr or lf before the next character is read. A cr directly following an lf, or
+   an lf directly following a cr, is the second half of the same line ending and
+   is skipped. */
+long getcunv(FILE* fp, filnum fn)
 {
     long c;
-    c = fgetc(fp); if (c != EOF) ungetc(c, fp);
-    return ((c=='\n'||c==EOF)?' ':c);
+
+    c = fgetc(fp);
+    if ((c == '\n' && filecr[fn]) || (c == '\r' && filelf[fn])) {
+        /* second half of a split line ending, skip it */
+        filecr[fn] = FALSE; filelf[fn] = FALSE;
+        c = fgetc(fp);
+    }
+    /* set flags on the current character */
+    filecr[fn] = c == '\r';
+    filelf[fn] = c == '\n';
+
+    return (c);
+}
+
+/* Check next character with universal line ending recognition. Returns the next
+   character without moving the file forward, skipping (and consuming) the second
+   half of a split line ending first. The cr/lf flags are not set for the
+   returned character, since it is not consumed. */
+long chkcunv(FILE* fp, filnum fn)
+{
+    long c;
+
+    c = fgetc(fp);
+    if ((c == '\n' && filecr[fn]) || (c == '\r' && filelf[fn])) {
+        /* second half of a split line ending; it is gone for good */
+        filecr[fn] = FALSE; filelf[fn] = FALSE;
+        c = fgetc(fp);
+    }
+    if (c != EOF) ungetc(c, fp);
+
+    return (c);
+}
+
+boolean eoffile(FILE* fp, filnum fn)
+{ long c; c = chkcunv(fp, fn); return (c == EOF); }
+
+boolean eolnfile(FILE* fp, filnum fn)
+{ long c; c = chkcunv(fp, fn); return (c == '\n' || c == '\r'); }
+
+char chkfile(FILE* fp, filnum fn)
+{
+    long c;
+    c = chkcunv(fp, fn);
+    return ((c=='\n'||c=='\r'||c==EOF)?' ':c);
 }
 
 long lengthfile(FILE* fp)
@@ -1768,14 +1812,14 @@ char buffn(filnum fn)
     long c;
 
     if (fn <= COMMANDFN) switch(fn) {
-        case INPUTFN:   c = chkfile(stdin); break;
-        case PRDFN:     c = chkfile(filtable[PRDFN]); break;
+        case INPUTFN:   c = chkfile(stdin, INPUTFN); break;
+        case PRDFN:     c = chkfile(filtable[PRDFN], PRDFN); break;
         case OUTPUTFN: case PRRFN: case ERRORFN:
         case LISTFN:    errore(READONWRITEONLYFILE); break;
         case COMMANDFN: c = bufcommand(); break;
     } else {
         if (filstate[fn] != fsread) errore(FILEMODEINCORRECT);
-        c = chkfile(filtable[fn]);
+        c = chkfile(filtable[fn], fn);
     }
 
     return (c);
@@ -1785,9 +1829,9 @@ void getfneoln(FILE* fp, filnum fn)
 {
     long c;
 
-    c = fgetc(fp);
+    c = getcunv(fp, fn);
     if (c == EOF && !fileoln[fn]) fileoln[fn] = TRUE;
-    else fileoln[fn] = c == '\n';
+    else fileoln[fn] = c == '\n' || c == '\r';
     if (c != EOF) filbof[fn] = FALSE;
 }
 void getfn(filnum fn)
@@ -1807,13 +1851,13 @@ void getfn(filnum fn)
 boolean chkeoffn(FILE* fp, filnum fn)
 {
     if (fn == INPUTFN) {
-        if ((eoffile(fp) && fileoln[fn]) || filbof[fn]) return (TRUE);
+        if ((eoffile(fp, fn) && fileoln[fn]) || filbof[fn]) return (TRUE);
         else return (FALSE);
     } else {
         if (filstate[fn] == fswrite)
             return ftell(filtable[fn]) >= lengthfile(filtable[fn]);
         else if (filstate[fn] == fsread) {
-            if ((eoffile(filtable[fn]) && fileoln[fn]) || filbof[fn])
+            if ((eoffile(filtable[fn], fn) && fileoln[fn]) || filbof[fn])
                 return (TRUE);
             else return (FALSE);
         } else { errore(FILENOTOPEN); return (FALSE); }
@@ -1839,8 +1883,8 @@ boolean eoffn(filnum fn)
 
 boolean chkeolnfn(FILE* fp, filnum fn)
 {
-    if ((eoffile(fp) && !fileoln[fn]) && !filbof[fn]) return (TRUE);
-    else return (eolnfile(fp));
+    if ((eoffile(fp, fn) && !fileoln[fn]) && !filbof[fn]) return (TRUE);
+    else return (eolnfile(fp, fn));
 }
 
 boolean eolnfn(filnum fn)
@@ -2152,6 +2196,8 @@ void resetfn(filnum fn, boolean bin)
     filstate[fn] = fsread;
     filbuff[fn] = FALSE;
     fileoln[fn] = FALSE;
+    filecr[fn] = FALSE;
+    filelf[fn] = FALSE;
     filbof[fn] = FALSE;
 }
 
@@ -2319,7 +2365,7 @@ void callsp(void)
                  popadr(ad); valfilrm(ad); fn = store[ad];
                  if (filstate[fn] == fswrite) pshint(TRUE);
                  else if (filstate[fn] == fsread)
-                   pshint(eoffile(filtable[fn]) && !filbuff[fn]);
+                   pshint(eoffile(filtable[fn], fn) && !filbuff[fn]);
                  break;
     case 7 /*eln*/: popadr(ad); valfil(ad); fn = store[ad];
                     pshint(eolnfn(fn));
@@ -2635,7 +2681,7 @@ void callsp(void)
                        }
                      else
                        for (i = 0; i < l; i++) {
-                         if (eoffile(filtable[fn])) errore(ENDOFFILE);
+                         if (eoffile(filtable[fn], fn)) errore(ENDOFFILE);
                          store[ad1] = fgetc(filtable[fn]);
                          putdef(ad1, TRUE);
                          ad1 = ad1+1;

--- a/source/parser.ins
+++ b/source/parser.ins
@@ -16,4 +16,4 @@
 !
 ! Declare the main library and protect it from recompiles
 !
-modulepath "lendian:mpb64"
+modulepath "lendian;mpb64"

--- a/source/pcom.ins
+++ b/source/pcom.ins
@@ -16,7 +16,7 @@
 !
 ! Declare the main library and protect it from recompiles
 !
-modulepath "lendian:mpb64"
+modulepath "lendian;mpb64"
 
 !
 ! Place the built product in the hosts tree

--- a/source/pgen/amd64/pgen.ins
+++ b/source/pgen/amd64/pgen.ins
@@ -16,7 +16,7 @@
 !
 ! CPU specific modules followed by CPU independent modules
 !
-modulepath "..:../.."
+modulepath "..;../.."
 
 !
 ! Place the built product in the hosts tree

--- a/source/pgen/arm64/pgen.ins
+++ b/source/pgen/arm64/pgen.ins
@@ -16,4 +16,4 @@
 !
 ! CPU specific modules followed by CPU independent modules
 !
-modulepath ".:..:./../.."
+modulepath ".;..;./../.."

--- a/source/pgen/psystem.c
+++ b/source/pgen/psystem.c
@@ -522,6 +522,8 @@ static boolean filanamtab[MAXFIL+1]; /* name has been assigned flags */
 static filsts filstate[MAXFIL+1]; /* file state holding */
 static boolean filbuff[MAXFIL+1]; /* file buffer full status */
 static boolean fileoln[MAXFIL+1]; /* last file character read was eoln */
+static boolean filecr[MAXFIL+1];  /* last file character read was cr */
+static boolean filelf[MAXFIL+1];  /* last file character read was lf */
 static boolean filbof[MAXFIL+1]; /* beginning of file */
 static varptr varlst; /* active var block pushdown stack */
 static varptr varfre; /* free var block entries */
@@ -1063,18 +1065,88 @@ Note: turns out this could be implemented by feof().
 
 *******************************************************************************/
 
-static boolean eoffile(
-    /** File to check */ FILE* fp
+/** ****************************************************************************
+
+Get next character with universal line ending recognition
+
+Reads the next character from a text file, recognizing any of the line ending
+forms crlf, lfcr, cr or lf as valid (the flip.c/IP Pascal algorithm). Two flags
+are kept per file, set on the current character being cr or lf before the next
+character is read. A cr directly following an lf, or an lf directly following a
+cr, is the second half of the same line ending and is skipped.
+
+*******************************************************************************/
+
+static long getcunv(
+    /** File to get character from */ FILE* fp,
+    /** Logical file number */        filnum fn
 )
 
-{ 
+{
 
-    long c; 
+    long c;
 
-    c = fgetc(fp); 
-    if (c != EOF) ungetc(c, fp); 
+    c = fgetc(fp);
+    if ((c == '\n' && filecr[fn]) || (c == '\r' && filelf[fn])) {
 
-    return (c == EOF); 
+        /* second half of a split line ending, skip it */
+        filecr[fn] = FALSE; filelf[fn] = FALSE;
+        c = fgetc(fp);
+
+    }
+    /* set flags on the current character */
+    filecr[fn] = c == '\r';
+    filelf[fn] = c == '\n';
+
+    return (c);
+
+}
+
+/** ****************************************************************************
+
+Check next character with universal line ending recognition
+
+Returns the next character from a text file without moving the file forward,
+skipping (and consuming) the second half of a split line ending first. The
+cr/lf flags are not set for the returned character, since it is not consumed.
+
+*******************************************************************************/
+
+static long chkcunv(
+    /** File to check */       FILE* fp,
+    /** Logical file number */ filnum fn
+)
+
+{
+
+    long c;
+
+    c = fgetc(fp);
+    if ((c == '\n' && filecr[fn]) || (c == '\r' && filelf[fn])) {
+
+        /* second half of a split line ending; it is gone for good */
+        filecr[fn] = FALSE; filelf[fn] = FALSE;
+        c = fgetc(fp);
+
+    }
+    if (c != EOF) ungetc(c, fp);
+
+    return (c);
+
+}
+
+static boolean eoffile(
+    /** File to check */       FILE* fp,
+    /** Logical file number */ filnum fn
+)
+
+{
+
+    long c;
+
+    c = chkcunv(fp, fn);
+
+    return (c == EOF);
 
 }
 
@@ -1087,17 +1159,17 @@ Expects a C file pointer, and returns true if the file is at EOLN.
 *******************************************************************************/
 
 static boolean eolnfile(
-    /** File to check */ FILE* fp
+    /** File to check */       FILE* fp,
+    /** Logical file number */ filnum fn
 )
 
-{ 
+{
 
-    long c; 
-    
-    c = fgetc(fp); 
-    if (c != EOF) ungetc(c, fp); 
+    long c;
 
-    return (c == '\n'); 
+    c = chkcunv(fp, fn);
+
+    return (c == '\n' || c == '\r');
 
 }
 
@@ -1111,17 +1183,17 @@ character is EOLN or EOF, returns space.
 *******************************************************************************/
 
 static char chkfile(
-    /** File to get character from */ FILE* fp
+    /** File to get character from */ FILE* fp,
+    /** Logical file number */        filnum fn
 )
 
 {
 
     long c;
 
-    c = fgetc(fp); 
-    if (c != EOF) ungetc(c, fp);
+    c = chkcunv(fp, fn);
 
-    return ((c=='\n'||c==EOF)?' ':c);
+    return ((c=='\n'||c=='\r'||c==EOF)?' ':c);
 
 }
 
@@ -1167,8 +1239,8 @@ static char buffn(
 
     if (fn <= COMMANDFN) switch(fn) {
 
-        case INPUTFN:   c = chkfile(stdin); break;
-        case PRDFN:     c = chkfile(filtable[PRDFN]); break;
+        case INPUTFN:   c = chkfile(stdin, INPUTFN); break;
+        case PRDFN:     c = chkfile(filtable[PRDFN], PRDFN); break;
         case OUTPUTFN: case PRRFN: case ERRORFN:
         case LISTFN:    errore(modnam, __LINE__, READONWRITEONLYFILE); break;
         case COMMANDFN: c = bufcommand(); break;
@@ -1176,7 +1248,7 @@ static char buffn(
     } else {
 
         if (filstate[fn] != fsread) errore(modnam, __LINE__, FILEMODEINCORRECT);
-        c = chkfile(filtable[fn]);
+        c = chkfile(filtable[fn], fn);
 
     }
 
@@ -1208,9 +1280,9 @@ static void getfneoln(
 
     long c;
 
-    c = fgetc(fp);
+    c = getcunv(fp, fn);
     if (c == EOF && !fileoln[fn]) fileoln[fn] = TRUE;
-    else fileoln[fn] = c == '\n';
+    else fileoln[fn] = c == '\n' || c == '\r';
     if (c != EOF) filbof[fn] = FALSE;
 
 }
@@ -1257,7 +1329,7 @@ static boolean chkeoffn(FILE* fp, filnum fn)
 
     if (fn == INPUTFN) {
 
-        if ((eoffile(fp) && fileoln[fn]) || filbof[fn]) return (TRUE);
+        if ((eoffile(fp, fn) && fileoln[fn]) || filbof[fn]) return (TRUE);
         else return (FALSE);
 
     } else {
@@ -1266,7 +1338,7 @@ static boolean chkeoffn(FILE* fp, filnum fn)
             return ftell(filtable[fn]) >= lengthfile(filtable[fn]);
         else if (filstate[fn] == fsread) {
 
-            if ((eoffile(filtable[fn]) && fileoln[fn]) || filbof[fn])
+            if ((eoffile(filtable[fn], fn) && fileoln[fn]) || filbof[fn])
                 return (TRUE);
             else return (FALSE);
 
@@ -1318,8 +1390,8 @@ static boolean chkeolnfn(FILE* fp, filnum fn)
 
 {
 
-    if ((eoffile(fp) && !fileoln[fn]) && !filbof[fn]) return (TRUE);
-    else return (eolnfile(fp));
+    if ((eoffile(fp, fn) && !fileoln[fn]) && !filbof[fn]) return (TRUE);
+    else return (eolnfile(fp, fn));
 
 }
 
@@ -2092,6 +2164,8 @@ static void resetfn(filnum fn, boolean bin)
     filstate[fn] = fsread;
     filbuff[fn] = FALSE;
     fileoln[fn] = FALSE;
+    filecr[fn] = FALSE;
+    filelf[fn] = FALSE;
     filbof[fn] = FALSE;
 
 }
@@ -2647,7 +2721,7 @@ boolean psystem_efb(
     if (filstate[fn] == fswrite) return(TRUE);
     else 
       if (filstate[fn] == fsread) 
-         return (eoffile(filtable[fn]) && !filbuff[fn]);
+         return (eoffile(filtable[fn], fn) && !filbuff[fn]);
       else return(FALSE);
 
 }
@@ -5615,6 +5689,8 @@ void psystem_libcatcfil(
         filstate[fn] = fsread;
         filbuff[fn] = FALSE;
         fileoln[fn] = FALSE;
+        filecr[fn] = FALSE;
+        filelf[fn] = FALSE;
         filbof[fn] = FALSE;
 
     }

--- a/source/pint.ins
+++ b/source/pint.ins
@@ -16,7 +16,7 @@
 !
 ! Declare the main library and protect it from recompiles
 !
-modulepath "plain:common:lendian:mpb64"
+modulepath "plain;common;lendian;mpb64"
 
 !
 ! Place the built product in the hosts tree

--- a/source/pmach.ins
+++ b/source/pmach.ins
@@ -16,7 +16,7 @@
 !
 ! Declare the main library and protect it from recompiles
 !
-modulepath "plain:common:lendian:mpb64"
+modulepath "plain;common;lendian;mpb64"
 
 !
 ! Place the built product in the hosts tree

--- a/utils/p2c.ins
+++ b/utils/p2c.ins
@@ -16,4 +16,4 @@
 !
 ! Declare the main library and protect it from recompiles
 !
-modulepath "../source/lendian:../source/mpb64:../source"
+modulepath "../source/lendian;../source/mpb64;../source"

--- a/utils/passym.ins
+++ b/utils/passym.ins
@@ -16,4 +16,4 @@
 !
 ! Declare the main library and protect it from recompiles
 !
-modulepath "../source/lendian:../source/mpb64:../source"
+modulepath "../source/lendian;../source/mpb64;../source"


### PR DESCRIPTION
## Summary

Three source fixes for the Pascal-P6 tools running **natively on Windows**, found bringing up `pc.exe` on a real Windows host. The wine cross builds passed regression only by luck: wine's heap happened to be zeroed where native Windows returns garbage.

### 1. Wrapper layer LLP64 fix (`libs/source/support.h`, `services_wrapper.h`)

The Pascaline/C binding layer assumed `long` is 64 bits. On win64 (LLP64/mingw) it is 32 bits, so every struct shared with compiled Pascal (filrec, pstring header, event records) had wrong offsets — pc read `filrec.next` at offset 184 of a 112-byte C struct and faulted on heap garbage (`dolist` "System fault"; pgen/pint externals/cmach crash the same way). Fix adopts psystem.c's existing convention: `#define long long long` under `_WIN32`, placed in `support.h` after the system and Ami includes so CRT prototypes and Ami structures keep their true types. `filrec.size/alloc` change from literal `long long` (which the macro would expand to `long long long long`) to plain `long`, restoring correct scaling on 32-bit targets too.

### 2. Universal line endings in psystem (`source/pgen/psystem.c`)

Text input now recognizes crlf, lfcr, cr and lf as one line ending (the flip.c / IP Pascal algorithm). Two flags are kept per file (`filecr[]`/`filelf[]` beside `fileoln[]`), set on the current character before the next is read; an lf directly after cr (or cr after lf) is the second half of the same ending and is skipped. Consumption goes through `getcunv()`, peeks through `chkcunv()`; binary reads untouched. A CRLF `pc.ins` previously produced a cascade of "Invalid command" errors on every line.

### 3. Module path separator is now ';' on all hosts (`pc/pc.pas`)

`:` collides with Windows drive letters: splitting `C:\...\libs:C:\...\source` yields a bare `C`, and pc exited **silently** through `winerr()` after `SetCurrentDirectory("C\")` failed (caught with gdb). The concatenated path strings are internal to the Pascal-P6 toolset, so one separator on every host avoids linux/windows divergence. **Migration:** `MODULEPATH` env vars written `a:b` become `a;b`; docs describing the module path as ':'-separated need the same update.

## Verification (native Windows, msys64/mingw64)

- Rebuilt win64 `services.a`/`psystem.a` with the fix; a `services.list` test program and the pc scanner stack run correctly natively (they crash with the old libs).
- Bootstrapped a native `pc.exe` without a working pc or pgen (pcom natively + pgen run as an interpreted deck under pint) — it proceeds past instruction file parsing, module path assembly, and file logging where the shipped binary faults.
- Windows host executables and hosts-tree libs are **not** included; they need a cross-rebuild + regression from the Linux flow with these sources.

## Known follow-ups (not in this PR)

- `network_support.c`: `unsigned long long` casts expand badly under the macro; its private `pstrrec` still has a 32-bit `len`.
- `source/cmach/extern.inc` `putlongset()` shifts a 4-byte `long` by up to 56 bits on win64 (garbles high set bytes).
- `winerr()`'s stderr message is lost when stdout is piped — the drive-letter failure was completely silent.
- The win64 hosts `psystem.a` predates the bundled bypass-stdio member (`stdio_printf` etc. absent), and the bypass stdio omits `rename()` on Windows while `STDIO_BYPASS` consumers reference `stdio_rename` — cmach needs a shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-on (commit `06379564`)

Consequences of fixes 2 and 3 above, found running the full regression:

- **`.ins` files migrated to `;`** — eight instruction files carry `:`-joined `modulepath` lists that fix 3's split-on-`;` would otherwise read as one path: `source/{pcom,parser,pint,pmach}.ins`, both `pgen.ins`, and `utils/{p2c,passym}.ins`. Single-path directives (the `pc.ins` files) are unaffected. (`utils/pasdoc.ins` also carries one but is untracked — flagged separately.)
- **cmach.c eoln-agnostic** — cmach has its own deck/file reader; it gets the same universal line-ending recognition psystem.c received (new `getcunv`/`chkcunv`; `eoffile`/`eolnfile`/`chkfile` take the file number for per-file cr/lf flags, reset in `resetfn`). Verified: LF regression unchanged, and a CRLF input reads byte-identically to LF.
- **`strings_test` golden** — `strings_test.dat` is a CRLF data file; `reads()` used to leave the `\r` in the string (`Now is the time\r`), which the golden captured — contradicting the test's own `s/b Now is the time` (no `\r`). The eoln fix reads it clean, so the golden loses the stray `\r` on line 57. (Keeping the `.dat` CRLF makes it a real regression test for the eoln fix.)

Still source-only — no binaries.
