### PR TITLE
Add wrapper header prerequisites to the win64 and arm64 archive rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,9 @@ $(LIBS)/win64/services.a: $(PASCALP6)/amitk/windows/services.c \
 	$(LIBS)/source/services_wrapper.asm \
 	$(LIBS)/source/services_wrapper.c \
 	$(LIBS)/source/services_support.c \
-	$(LIBS)/source/support.c
+	$(LIBS)/source/support.c \
+	$(LIBS)/source/services_wrapper.h \
+	$(LIBS)/source/support.h
 	@echo
 	@echo "Building services for win64..."
 	@echo
@@ -370,7 +372,8 @@ $(LIBS)/win64/terminal.a: $(AMIWIN)/terminal.c \
 	$(LIBS)/source/terminal_wrapper.asm \
 	$(LIBS)/source/terminal_wrapper.c \
 	$(LIBS)/source/terminal_support.c \
-	$(LIBS)/source/support.c
+	$(LIBS)/source/support.c \
+	$(LIBS)/source/support.h
 	@echo
 	@echo "Building terminal for win64..."
 	@echo
@@ -411,7 +414,8 @@ $(LIBS)/win64/graphics.a: $(AMIWIN)/graphics.c \
 	$(LIBS)/source/graphics_wrapper.asm \
 	$(LIBS)/source/graphics_wrapper.c \
 	$(LIBS)/source/graphics_support.c \
-	$(LIBS)/source/support.c
+	$(LIBS)/source/support.c \
+	$(LIBS)/source/support.h
 	@echo
 	@echo "Building graphics for win64..."
 	@echo
@@ -480,7 +484,8 @@ ifneq ($(AMITK),)
 $(LIBS)/win64/sound.a: $(AMIWIN)/sound.c \
 	$(LIBS)/source/sound_wrapper.asm \
 	$(LIBS)/source/sound_wrapper.c \
-	$(LIBS)/source/support.c
+	$(LIBS)/source/support.c \
+	$(LIBS)/source/support.h
 	@echo
 	@echo "Building sound for win64..."
 	@echo
@@ -505,7 +510,8 @@ $(LIBS)/win64/network.a: $(AMIWIN)/network.c \
 	$(LIBS)/source/network_wrapper.asm \
 	$(LIBS)/source/network_wrapper.c \
 	$(LIBS)/source/network_support.c \
-	$(LIBS)/source/support.c
+	$(LIBS)/source/support.c \
+	$(LIBS)/source/support.h
 	@echo
 	@echo "Building network for win64..."
 	@echo
@@ -587,7 +593,9 @@ $(LIBS)/arm64/services.a: $(AMI)/services.c \
 	$(LIBS)/source/services_wrapper_arm64.asm \
 	$(LIBS)/source/services_wrapper.c \
 	$(LIBS)/source/services_support.c \
-	$(LIBS)/source/support.c
+	$(LIBS)/source/support.c \
+	$(LIBS)/source/services_wrapper.h \
+	$(LIBS)/source/support.h
 	@echo
 	@echo "Building services for arm64..."
 	@echo


### PR DESCRIPTION
## Summary

The win64 `services`/`terminal`/`graphics`/`sound`/`network` and arm64 `services` archive rules listed only the `.c`/`.asm` sources as prerequisites — not `support.h` / `services_wrapper.h` — even though every rule compiles `support.c` and wrapper sources that include those headers. The linux rules already carry the header prerequisites; this brings the win64/arm64 rules in line.

## Why it matters right now

The LLP64 fix (#538) changed **only headers**, so the products rebuild (#549) considered the win64 archives up to date and shipped the pre-fix wrapper objects inside the rebuilt Windows executables.

Verified on native Windows against the freshly pulled tree:

- `pc hello` parses the CRLF `pc.ins` cleanly (psystem eoln fix ✓) and shows a `;`-separated module path (pc.pas fix ✓) — those rebuilt because their **source** files changed — but then dies with the old `System fault`.
- A `services.list` test program linked against the pulled `hosts/windows/x86/bit64/libs/services.a` prints `dian.p6` for `g_endian.p6` (string data read at the old 4-byte len offset) and crashes; the pulled `pint.exe` fails its list test identically to the pre-fix binary.

## For the next rebuild

The stale archives may carry timestamps newer than the headers, so force the first rebuild — `make -B` on the win64 lib targets, or `touch libs/source/support.h libs/source/services_wrapper.h` — then relink the Windows host executables and refresh the hosts tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)