### PR TITLE
Fix win64 native execution: commit the full stack, section-relative DWARF references

### DIFF
--- a/pc/pc.pas
+++ b/pc/pc.pas
@@ -2423,9 +2423,16 @@ begin { dolink }
       { The PE default stack reserve (2mb) is a quarter of the linux default
         (8mb). Deep recursion that fits on linux (the recursive descent
         compiler compiling itself, deviant sources, user recursion) would
-        overflow the windows stack, so reserve the linux default explicitly. }
-      if fwindows then begin putstr('-Wl,--stack,');
-         ints(numstr, stksiz); putstr(numstr); putchr(' ') end;
+        overflow the windows stack, so reserve the linux default explicitly.
+        The full reserve is also COMMITTED: windows grows the stack through a
+        single guard page, and pgen generated code allocates large and
+        variable sized frames with plain rsp adjustments (no stack probes),
+        which fault when they skip past the guard page. Committing the whole
+        stack up front removes the guard mechanism. -Xlinker is used because
+        -Wl, would split the reserve,commit pair at the comma. }
+      if fwindows then begin putstr('-Xlinker --stack=');
+         ints(numstr, stksiz); putstr(numstr);
+         putchr(','); putstr(numstr); putchr(' ') end;
       { An I/O library (terminal or graphics) installs its I/O overrides from a
         constructor in its module object. A program that does not call any of
         its functions (e.g. promoted serial code) would leave that object out

--- a/source/pgen/independent.pas
+++ b/source/pgen/independent.pas
@@ -2770,9 +2770,15 @@ begin
 end;
 
 { write a string reference attribute (DW_FORM_strp) }
+{ A reference into another debug section must be section relative on
+  windows/COFF (.secrel32): a .long there is a 32 bit absolute relocation,
+  which the linker faults when the debug sections land beyond 32 bit range. }
 procedure dwstrref(s: pstring);
 begin
-  writeln(prr, '        .long   .Ldw', dwaddstr(s):1)
+  if windows then
+    writeln(prr, '        .secrel32   .Ldw', dwaddstr(s):1)
+  else
+    writeln(prr, '        .long   .Ldw', dwaddstr(s):1)
 end;
 
 { DWARF abbreviation table constants }
@@ -3570,7 +3576,11 @@ begin
   writeln(prr, '        .long   .Ldw_info_end - .Ldw_info_hdr /* unit length */');
   writeln(prr, '.Ldw_info_hdr:');
   writeln(prr, '        .short  4 /* DWARF version */');
-  writeln(prr, '        .long   .Ldw_abbrev_start /* debug_abbrev offset */');
+  { cross section reference: section relative on windows/COFF (see dwstrref) }
+  if windows then
+    writeln(prr, '        .secrel32   .Ldw_abbrev_start /* debug_abbrev offset */')
+  else
+    writeln(prr, '        .long   .Ldw_abbrev_start /* debug_abbrev offset */');
   adrsz := dwarf_addr_size;
   writeln(prr, '        .byte   ', adrsz:1, ' /* address size */');
 
@@ -3594,7 +3604,11 @@ begin
     writeln(prr, ' /* DW_AT_high_pc (no functions) */')
   end;
   { line number table reference }
-  writeln(prr, '        .long   .Ldw_line_start /* DW_AT_stmt_list */');
+  { cross section reference: section relative on windows/COFF (see dwstrref) }
+  if windows then
+    writeln(prr, '        .secrel32   .Ldw_line_start /* DW_AT_stmt_list */')
+  else
+    writeln(prr, '        .long   .Ldw_line_start /* DW_AT_stmt_list */');
 
   { emit base type DIEs }
   dwldef(dwlint); writeln(prr);


### PR DESCRIPTION
## Summary

The last two blockers for `pc hello` on **real Windows** — both invisible under Wine and on Linux, which is why the regression passes while native Windows fails.

### 1. Commit the full stack on windows links (`pc/pc.pas`)

pgen.exe from the products-2 rebuild segfaulted on any input. gdb showed the fault at a `push` immediately after a ~20 KB `sub %rax,%rsp`: **pgen-generated code allocates large and variable-sized frames with plain rsp adjustments — no stack probes.** Windows grows the stack through a single guard page; skipping past it faults. The PE headers confirmed an 8 MB reserve with a single 4 KB page committed. Linux has no guard protocol (any faulting stack access grows it) and Wine doesn't enforce one.

pc now emits `-Xlinker --stack=N,N` (reserve **and commit**; `-Wl,` would split the pair at the comma). With the whole stack committed there are no guard pages to miss. Emitting real stack probes from pgen is the deeper long-term alternative.

### 2. Section-relative DWARF references on windows (`source/pgen/independent.pas`)

With pgen running, the final link failed: `relocation truncated to fit: IMAGE_REL_AMD64_ADDR32 against .debug_abbrev/.debug_str/.debug_line`. pgen emitted `.long` for references from `.debug_info` into other debug sections — a 32-bit *absolute* relocation, fine on ELF, faulted by mingw ld when debug sections land beyond 32-bit range. On windows those three reference kinds (`.Ldw_abbrev_start`, `.Ldw_line_start`, `DW_FORM_strp` string labels) are now `.secrel32`, matching COFF DWARF convention. ELF emission unchanged. Same-section length expressions stay `.long`.

## Verification (native Windows)

- PE-header-patched the prebuilt tools to commit=reserve as a stopgap: pgen immediately went from segfault to "Program generation complete".
- Ran pgen with the secrel32 change as an interpreted deck: generated `hello.s` carries `.secrel32`, assembles, links **with debug info intact** (no `-s` stripping needed), and `hello.exe` prints **"Hello, world"** — the full `pc hello` chain works.
- `pc.pas` and `independent.pas` compile clean with pcom; the `-Xlinker --stack=8388608,8388608` link line verified against mingw gcc/ld 15.2.

## Rebuild notes

- Rebuild the **native linux pc first** so the tool that links the windows executables carries the new `--stack` emission, then relink the windows host tools and refresh the hosts tree.
- On this Windows machine the current hosts-tree tools have been PE-patched locally (commit=reserve) and work; they'll be replaced by the next products pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)