### PR TITLE
cmach: honor windows temp conventions for anonymous files

### DIFF
--- a/source/cmach/cmach.c
+++ b/source/cmach/cmach.c
@@ -2227,7 +2227,19 @@ FILE* opentemp(filnum fn, const char* mode)
 {
     int fd;
     const char* td;
-    td = getenv("TMPDIR"); if (!td || !*td) td = "/tmp";
+    td = getenv("TMPDIR");
+#ifdef _WIN32
+    /* windows has no /tmp: honor the windows temp conventions, falling back
+       to the current directory. The generated name is recorded in filnamtab
+       and reused by resetfn's fopen, so a /tmp path there would fail to reopen
+       the anonymous file (reported as file open fail rather than the intended
+       error). Matches opentemp in psystem.c. */
+    if (!td || !*td) td = getenv("TMP");
+    if (!td || !*td) td = getenv("TEMP");
+    if (!td || !*td) td = ".";
+#else
+    if (!td || !*td) td = "/tmp";
+#endif
     snprintf(filnamtab[fn], FILLEN+1, "%s/p6tmpXXXXXX", td);
     fd = mkstemp(filnamtab[fn]); /* securely create the temp file and its name */
     if (fd < 0) return NULL;


### PR DESCRIPTION
## Summary

cmach's `opentemp` fell back to `/tmp` when `TMPDIR` was unset, which doesn't exist for a native Windows process. The generated temp name is recorded in `filnamtab` and reused by `resetfn`'s `fopen`, so **reset of an anonymous file** (`rewrite` then `reset` — e.g. a local `file of integer`) failed to reopen it and reported **"File open fail"**, masking the error the program was actually meant to hit.

Fix: on Windows, fall back through `TMP` then `TEMP` (the Windows conventions) to the current directory — the same fix already in psystem.c's `opentemp`.

## Impact — the PRT runtime-error cluster under `--cmach`

This was the common cause behind the ~33 failing runtime deviance tests in the `--cmach` PRT run (66 diff lines). Those tests exercise file-mode/buffer errors using anonymous files, and all hit the `/tmp` reopen failure first. After the fix they raise their intended runtime errors:

| test | was | now (matches golden) |
|---|---|---|
| 1709 | [16] File open fail | **[22] File mode incorrect** |
| 1712 | [16] File open fail | **[17] File buffer variable undefined** |
| 1714 | [16] File open fail | **[18] File mode incorrect** |
| 1716 | [16] File open fail | **[21] End of file** |

Verified on native Windows (make-built cmach). Full PRT run confirming the aggregate count is included in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)