### PR TITLE
cmach: bounds-check set membership to avoid negative-shift UB

### DIFF
--- a/source/cmach/cmach.c
+++ b/source/cmach/cmach.c
@@ -1418,6 +1418,10 @@ void sdif(settype s1, settype s2)
 
 boolean sisin(long i, settype s)
 {
+    /* An element outside the set's universe (SETLOW..SETHIGH) is simply not a
+       member. Guarding here also avoids a negative shift count (undefined
+       behavior) for i < 0, e.g. -1/8 == 0 with -1%8 == -1 giving 1<<-1. */
+    if (i < SETLOW || i > SETHIGH) return (FALSE);
     return (!!(s[i/8] & 1<<i%8));
 }
 


### PR DESCRIPTION
## Problem

`sisin()` (the C interpreter's `IN` operator) tested set membership without checking that the element lies within the set universe (`SETLOW`..`SETHIGH`):

```c
boolean sisin(long i, settype s)
{
    return (!!(s[i/8] & 1<<i%8));
}
```

For a negative element such as `-1`, C gives `i/8 == 0` and `i%8 == -1`, so the body computes `1 << -1` — a **negative shift count, which is undefined behavior**. On x86 the count masks to 31 and `1<<31` ANDs nonzero against `s[0]`, so the test wrongly returns TRUE.

## Symptom

`sample_programs/startrek` aborted under **cmach** (but not pint/pmach) with runtime error 446 (Value out of range). `moveintra` guards its array index:

```pascal
WHILE (ROUND(xpos) IN [0..quadsize]) AND (ROUND(ypos) IN [0..quadsize]) ...
  IF quadrant[ROUND(xpos), ROUND(ypos)] = snothing THEN
```

When `ROUND` reaches `-1`, a correct `IN [0..7]` returns FALSE and the loop exits (as pint and pmach do). cmach's buggy `sisin` returned TRUE, entered the loop body, indexed `quadrant[-1]`, and the range check correctly caught it — aborting the program.

## Fix

Guard the universe — an element outside `SETLOW`..`SETHIGH` is simply not a member:

```c
if (i < SETLOW || i > SETHIGH) return (FALSE);
```

This is a **cross-platform correctness fix**; the UB merely happened to surface on the Windows build. Only `pi_inn` reaches `sisin` with an arbitrary user value; the other caller (`pi_chks`) already iterates within `SETLOW`..`SETHIGH`.

## Verification

Fixed cmach runs startrek to completion (same ending as pint/pmach) and matches its golden (`diff -Bw` = 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA