### PR TITLE
pc: port the package model to windows (win64)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,8 @@ win64: $(LIBS)/win64/psystem.a $(LIBS)/win64/main.o $(LIBS)/win64/services.a \
 	$(LIBS)/win64/terminal.a $(LIBS)/win64/graphics.a \
 	source/graph/win64/graphics.a $(LIBS)/win64/gnome_widgets.o \
 	$(LIBS)/win64/sound.a $(LIBS)/win64/network.a \
+	$(BUILD)/win64/cmach_stdio.o $(BUILD)/win64/cmach_package.o \
+	$(BUILD)/win64/cmach_package_min.o \
 	$(WINCELL)/bin/cmach.exe
 
 arm64: $(LIBS)/arm64/psystem.a $(LIBS)/arm64/main.o $(LIBS)/arm64/services.a
@@ -996,6 +998,28 @@ $(BUILD)/cmach/cmach_package_min.o: $(SOURCE)/cmach/cmach.c
 	mkdir -p $(BUILD)/cmach
 	$(CC) $(CFLAGS) -DPACKAGE -DGPC=0 \
 		-o $(BUILD)/cmach/cmach_package_min.o -c $(SOURCE)/cmach/cmach.c
+
+# Windows x64 package objects. The same two builds as the native pair above,
+# compiled with the win64 toolchain and the Ami non-bypass stdio (WIN_STDIO_INC),
+# exactly as the standalone win64 cmach.exe is built -- so a windows package
+# hosts file I/O identically to the tested cmach.exe. pc links these against the
+# per-program deck plus cmach_stdio.o (the shared Ami stdio object below).
+# cmach_package.o carries -DEXTERNALS (services/sound/network); the _min build
+# omits it for programs that use no externals.
+$(BUILD)/win64/cmach_stdio.o: $(AMILIBC)/stdio.c
+	mkdir -p $(BUILD)/win64
+	$(WINCC) $(WINCFLAGS) $(CPPFLAGS64LE) $(WIN_STDIO_INC) \
+		-o $(BUILD)/win64/cmach_stdio.o -c $(AMILIBC)/stdio.c
+
+$(BUILD)/win64/cmach_package.o: $(SOURCE)/cmach/cmach.c $(SOURCE)/cmach/extern.inc
+	mkdir -p $(BUILD)/win64
+	$(WINCC) $(WINCFLAGS) $(CPPFLAGS64LE) -DEXTERNALS $(WIN_STDIO_INC) -DPACKAGE -DGPC=0 \
+		-o $(BUILD)/win64/cmach_package.o -c $(SOURCE)/cmach/cmach.c
+
+$(BUILD)/win64/cmach_package_min.o: $(SOURCE)/cmach/cmach.c
+	mkdir -p $(BUILD)/win64
+	$(WINCC) $(WINCFLAGS) $(CPPFLAGS64LE) $(WIN_STDIO_INC) -DPACKAGE -DGPC=0 \
+		-o $(BUILD)/win64/cmach_package_min.o -c $(SOURCE)/cmach/cmach.c
 
 # cmacht and cmachg are the terminal and graphics flavors of cmach, mirroring
 # pmacht/pmachg: the same cmach.c built with -DTERMINAL / -DGRAPHICS so it hosts

--- a/pc/pc.pas
+++ b/pc/pc.pas
@@ -2175,6 +2175,7 @@ var p, n, e: filnam;  { path components }
     sndarch: filnam;  { sound archive (package externals) }
     netarch: filnam;  { network archive (package externals) }
     psstdio: filnam;  { psystem bypass stdio object (package externals) }
+    cmstdio: filnam;  { win64 cmach Ami stdio object (windows package) }
     toolfn:  filnam;  { toolchain command holder }
     numstr:  filnam;  { number to string conversion holder }
 
@@ -2333,6 +2334,39 @@ begin { dolink }
               models (services, sound, network), so all three archives are
               linked unconditionally, exactly as the standalone cmach does. pc
               bridges its build config to the C define flags here. }
+            if hostid = 3 then begin { windows host }
+
+               { Windows package: mirror the standalone win64 cmach.exe -- the
+                 win64 -DEXTERNALS -DPACKAGE object, the per-program deck, the
+                 Ami non-bypass stdio object, and the win64 external archives
+                 with their windows dependency stack (WINCMACHLIBS). No ALSA/
+                 fluidsynth/glib: the windows externals resolve to winmm and the
+                 socket libraries. }
+               services.maknam(fnc, pgmpath, '../build/win64/cmach_package', 'o');
+               services.fulnam(fnc);
+               if not exists(fnc) then error('win64 cmach_package.o not found');
+               services.maknam(cmstdio, pgmpath, '../build/win64/cmach_stdio', 'o');
+               services.fulnam(cmstdio);
+               services.maknam(servarch, pgmpath, '../libs/win64/services', 'a');
+               services.fulnam(servarch);
+               services.maknam(sndarch, pgmpath, '../libs/win64/sound', 'a');
+               services.fulnam(sndarch);
+               services.maknam(netarch, pgmpath, '../libs/win64/network', 'a');
+               services.fulnam(netarch);
+               putstr(ccname);
+               putstr(' -static -g3 -o '); putstr(fns); putchr(' ');
+               putstr(fnc); putchr(' ');
+               putstr('program_code.c'); putchr(' ');
+               putstr(cmstdio); putchr(' ');
+               putstr(servarch); putchr(' ');
+               putstr(sndarch); putchr(' ');
+               putstr(netarch); putchr(' ');
+               putstr('-lssl -lcrypto -lwinmm -lwsock32 -lws2_32');
+               putstr(' -lcrypt32 -lm -lpthread');
+               excact(cmdbuf) { execute command buffer action }
+
+            end else begin
+
             services.maknam(fnc, pgmpath, '../build/cmach/cmach_package', 'o');
             services.fulnam(fnc);
             if not exists(fnc) then error('cmach_package.o not found');
@@ -2361,10 +2395,33 @@ begin { dolink }
             putstr(' -lglib-2.0 -lpcre -lpthread -ldl -lm');
             excact(cmdbuf) { execute command buffer action }
 
+            end
+
          end else begin
 
             { No Ami externals: a minimal package (cmach plus the embedded
               deck) that builds without the external dependency stack. }
+            if hostid = 3 then begin { windows host }
+
+               { Windows minimal package: the win64 -DPACKAGE object (built with
+                 the Ami non-bypass stdio, no -DEXTERNALS) plus the deck and the
+                 shared cmach_stdio.o object. File I/O then matches the standalone
+                 win64 cmach.exe; no external dependency stack is needed. }
+               services.maknam(fnc, pgmpath, '../build/win64/cmach_package_min', 'o');
+               services.fulnam(fnc);
+               if not exists(fnc) then error('win64 cmach_package_min.o not found');
+               services.maknam(cmstdio, pgmpath, '../build/win64/cmach_stdio', 'o');
+               services.fulnam(cmstdio);
+               putstr(ccname);
+               putstr(' -static -g3 -o '); putstr(fns); putchr(' ');
+               putstr(fnc); putchr(' ');
+               putstr('program_code.c'); putchr(' ');
+               putstr(cmstdio); putchr(' ');
+               putstr('-lm');
+               excact(cmdbuf) { execute command buffer action }
+
+            end else begin
+
             services.maknam(fnc, pgmpath, '../build/cmach/cmach_package_min', 'o');
             services.fulnam(fnc);
             if not exists(fnc) then error('cmach_package_min.o not found');
@@ -2374,6 +2431,8 @@ begin { dolink }
             putstr('program_code.c'); putchr(' ');
             putstr('-lm');
             excact(cmdbuf) { execute command buffer action }
+
+            end
 
          end
 

--- a/source/genobj.pas
+++ b/source/genobj.pas
@@ -145,7 +145,11 @@ begin (*xlate*)
     readln(prd)
   end;
   writeln(prr, '};');
-  write(prr, 'long program_code_len = 0x'); wrtnum(prr, ad, 16, 8, true);
+  { Emit the length as 'long long' (64-bit on every target) rather than 'long'.
+    cmach reads this extern as a full address word; on windows (LLP64) cmach.c
+    remaps long to long long, so a plain 'long' here would store only 32 bits
+    and cmach would read 8, picking up garbage high bits and a wild pctop. }
+  write(prr, 'long long program_code_len = 0x'); wrtnum(prr, ad, 16, 8, true);
   writeln(prr, ';');
 end;
 


### PR DESCRIPTION
## Problem

Package mode (`pc -package`) links a prebuilt cmach object (compiled `-DPACKAGE`) against the per-program deck to produce a self-contained executable. It was Linux-only in two ways, so on Windows every `--package` test failed:

1. **Link failure** — pc reached for `build/cmach/cmach_package*.o` (glibc ELF objects) and the ALSA/fluidsynth/glib/dl stack. On Windows the ELF objects' glibc symbols (`__ctype_b_loc`, `__isoc99_fscanf`, `stdin`/`stderr`) don't exist under mingw.
2. **Deck-length width bug** — cmach reads `program_code_len` as a full address word; on Windows (LLP64) cmach.c remaps `long`→`long long` (64-bit), but genobj emitted a plain `long` (32-bit). cmach read 8 bytes where 4 were written → garbage high bits → wild `pctop` → the load loop ran off `store[]` and **segfaulted**. Decks whose adjacent bytes were zero (hello, iso7185pat) worked by luck; qsort, p2/roman and several PRT sub-tests segfaulted.

## Fix

**Makefile** — add win64 builds of the two package objects (win64 toolchain + Ami non-bypass stdio, mirroring the standalone win64 `cmach.exe`) plus a shared `cmach_stdio.o`; added to the `win64` target.

**pc.pas** — the package link branches on the Windows host (`hostid = 3`, since `fwindows` is only auto-set in pgen mode). It links the `build/win64` object + deck + `cmach_stdio.o`, with `WINCMACHLIBS` (winmm/sockets/ssl) for the externals variant or just `-lm` for the minimal one.

**genobj.pas** — emit `program_code_len` as `long long` (64-bit on every target), matching the width cmach reads. Harmless on LP64 hosts.

## Verification (on Windows)

hello, roman, prime, qsort, fbench, drystone, startrek, basics, iso7185pat (heavy file I/O), pascals, standardp, pascaline, strings_test, services_test — all build as packages and run with **0 diffs** vs golden. qsort/p2/roman/PRT — the width-bug victims — now pass. Full `--package` regression to be confirmed in a normal terminal (the nested-spawn artifact confounds it under the Claude tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA