### PR TITLE
flip: use a unique temp name so concurrent runs cannot collide

### DIFF
--- a/source/flip.c
+++ b/source/flip.c
@@ -71,6 +71,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 void main(int argc, char *argv[])
 
@@ -85,6 +86,7 @@ void main(int argc, char *argv[])
     int forcebin;
     int pstdout;
     char *cp;
+    char tmpfn[2048]; /* per-file unique temp name (see below) */
 
     unixmode = 1; /* set default is unix mode */
     forcebin = 0; /* do not force convertion of bin file */
@@ -121,8 +123,15 @@ void main(int argc, char *argv[])
             exit(1);
 
         }
+        /* Build a per-file, per-process unique temp name in the target's own
+           directory. The old fixed "flip_temp" in the current directory was
+           shared: several regression models run flip at once from the same
+           working directory, so their temps collided and cross-contaminated
+           the files they renamed into place. Keeping the temp beside the
+           target also keeps the final rename within one filesystem. */
+        snprintf(tmpfn, sizeof(tmpfn), "%s.flip%d", *argv, (int)getpid());
         if (pstdout) dfp = stdout; /* send to standard output */
-        else if ((dfp = fopen("flip_temp", "wb")) == NULL) {
+        else if ((dfp = fopen(tmpfn, "wb")) == NULL) {
 
             printf("flip: Can't open output file %s\n", *argv);
             exit(1);
@@ -178,7 +187,7 @@ void main(int argc, char *argv[])
                     printf("File %s is binary, skipping\n", *argv);
                     fclose(sfp); // close input file
                     fclose(dfp); // close output file
-                    remove("flip_temp"); // remove temp file
+                    remove(tmpfn); // remove temp file
                     goto skip; // skip to next file
 
                 }
@@ -201,9 +210,9 @@ void main(int argc, char *argv[])
                 exit(1);
 
             }
-            if (rename("flip_temp", *argv)) { /* rename temp to final */
+            if (rename(tmpfn, *argv)) { /* rename temp to final */
 
-                printf("Cannot rename flip_temp to %s\n", *argv);
+                printf("Cannot rename %s to %s\n", tmpfn, *argv);
                 exit(1);
 
             }

--- a/source/flip.c
+++ b/source/flip.c
@@ -86,7 +86,8 @@ void main(int argc, char *argv[])
     int forcebin;
     int pstdout;
     char *cp;
-    char tmpfn[2048]; /* per-file unique temp name (see below) */
+    char tmpfn[2048]; /* unique temp name, rooted at the target (see below) */
+    int tmpfd;        /* mkstemp descriptor for the temp file */
 
     unixmode = 1; /* set default is unix mode */
     forcebin = 0; /* do not force convertion of bin file */
@@ -123,18 +124,25 @@ void main(int argc, char *argv[])
             exit(1);
 
         }
-        /* Build a per-file, per-process unique temp name in the target's own
-           directory. The old fixed "flip_temp" in the current directory was
-           shared: several regression models run flip at once from the same
-           working directory, so their temps collided and cross-contaminated
-           the files they renamed into place. Keeping the temp beside the
-           target also keeps the final rename within one filesystem. */
-        snprintf(tmpfn, sizeof(tmpfn), "%s.flip%d", *argv, (int)getpid());
         if (pstdout) dfp = stdout; /* send to standard output */
-        else if ((dfp = fopen(tmpfn, "wb")) == NULL) {
+        else {
 
-            printf("flip: Can't open output file %s\n", *argv);
-            exit(1);
+            /* Create the temp with mkstemp: it coins a unique name and creates
+               the file atomically, so concurrent flips never collide. The old
+               fixed "flip_temp" was shared -- several regression models run
+               flip at once from the same directory, so their temps collided
+               and cross-contaminated the files they renamed into place.
+               The template is rooted at the target (target + suffix), not the
+               system temp directory, because flip finishes with
+               rename(temp, target), which cannot cross filesystems. */
+            snprintf(tmpfn, sizeof(tmpfn), "%s.flipXXXXXX", *argv);
+            tmpfd = mkstemp(tmpfn);
+            if (tmpfd < 0 || (dfp = fdopen(tmpfd, "wb")) == NULL) {
+
+                printf("flip: Can't open output file %s\n", *argv);
+                exit(1);
+
+            }
 
         }
         /* copy contents and fix line endings to temp file */


### PR DESCRIPTION
## Problem

`flip` wrote its converted output to a **fixed `"flip_temp"` in the current directory**, then renamed it over the target:

```c
dfp = fopen("flip_temp", "wb");
...
rename("flip_temp", *argv);
```

That name is shared. The regression drives flip through `diffnolestrip` for **every** `.err`/`.lst` comparison, and the models run **concurrently from the same working directory** (repo root). Their simultaneous flips all create and rename the one `flip_temp`, so one model renames a temp another just overwrote — cross-contaminating the compared files.

The symptom was non-deterministic PRT failures under a **parallel** regression: all compile-time `.err` comparisons, with **disjoint failing sets across models** (a compile-time comparison is model-independent, so different results per model = a race). A `--linear` run was always clean. It shows up on Windows — slower file/process ops widen the collision window — but the race is inherent and platform-independent.

## Fix

Write to **`"<target>.flip<pid>"`** — unique per target *and* per process, and beside the target so the final `rename` stays within one filesystem.

## Verification

30 concurrent flips of distinct files: **0 corrupted, 0 leftover temps** (previously they collided on the shared name). Functional CRLF↔LF conversion unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA