### PR TITLE
psystem: bounds-check set membership to avoid negative-shift UB

### DIFF
--- a/source/pgen/psystem.c
+++ b/source/pgen/psystem.c
@@ -882,6 +882,10 @@ static void sdif(settype s1, settype s2)
 
 static boolean sisin(long i, settype s)
 {
+    /* An element outside the set's universe (SETLOW..SETHIGH) is simply not a
+       member. Guarding here also avoids a negative shift count (undefined
+       behavior) for i < 0, e.g. -1/8 == 0 with -1%8 == -1 giving 1<<-1. */
+    if (i < SETLOW || i > SETHIGH) return (FALSE);
     return (!!(s[i/8] & 1<<i%8));
 }
 
@@ -6007,6 +6011,10 @@ boolean psystem_setsin(
 
 {
 
+    /* An element outside the set's universe (SETLOW..SETHIGH) is simply not a
+       member. Guarding here also avoids a negative shift count (undefined
+       behavior) for i < 0, e.g. -1/8 == 0 with -1%8 == -1 giving 1<<-1. */
+    if (i < SETLOW || i > SETHIGH) return (FALSE);
     return (!!(s[i/8] & 1<<i%8));
 
 }


### PR DESCRIPTION
## Problem

The pgen native runtime's set-membership tests — `sisin()` and the exported `psystem_setsin()` that generated code calls for the `IN` operator — have the same defect fixed for cmach in #563: no check that the element lies within the set universe (`SETLOW`..`SETHIGH`).

```c
return (!!(s[i/8] & 1<<i%8));
```

For a negative element such as `-1`, C gives `i/8 == 0` and `i%8 == -1`, so this computes `1 << -1` — a **negative shift count, undefined behavior**.

## Why it appeared now

`sample_programs/startrek` passed pgen before but failed right after a fresh `make -B`. The UB is compiler/build dependent — the rebuild flipped it to return TRUE where the previous binary happened to return FALSE. `moveintra` guards its array index with `(ROUND(x) IN [0..quadsize])`; when `ROUND` reaches `-1`, a correct `IN` returns FALSE and exits the loop (as pint/pmach do), but the buggy test returned TRUE, indexed `quadrant[-1]`, and aborted with `Value out of range`.

## Fix

Guard the universe in both functions — an element outside `SETLOW`..`SETHIGH` is not a member. This completes #563 (which fixed only cmach.c); the same C runtime bug lived in the pgen runtime. Cross-platform correctness fix.

## Verification

psystem.c compiles clean with the win64 toolchain. (The negative-shift path is the same one already proven fixed for cmach in #563, where startrek then matched its golden.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA