### PR TITLE
win64: fix the graphics/terminal program link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -436,11 +436,13 @@ $(LIBS)/win64/graphics.a: $(AMIWIN)/graphics.c \
 		-o $(BUILD)/win64/graphics.o -c $(AMIWIN)/graphics.c
 	$(WINCC) $(WINCFLAGS) $(WINGRAPHCPP) \
 		-o $(BUILD)/win64/graph_services.o -c $(AMIWIN)/services.c
+	$(WINCC) $(WINCFLAGS) $(WINGRAPHCPP) \
+		-o $(BUILD)/win64/graph_config.o -c $(PASCALP6)/amitk/utils/config.c
 	rm -f $(LIBS)/win64/graphics.a
 	$(WINAR) rc $(LIBS)/win64/graphics.a $(BUILD)/win64/graphics_wrapper_asm.o \
 		$(BUILD)/win64/graphics_wrapper.o $(BUILD)/win64/graphics_support.o \
 		$(BUILD)/win64/graphics.o $(BUILD)/win64/graph_services.o \
-		$(BUILD)/win64/support.o
+		$(BUILD)/win64/graph_config.o $(BUILD)/win64/support.o
 	mkdir -p $(WINCELL)/libs
 	cp $(LIBS)/win64/graphics.a $(WINCELL)/libs
 
@@ -459,7 +461,7 @@ source/graph/win64/graphics.a: $(LIBS)/win64/graphics.a
 	$(WINAR) rc source/graph/win64/graphics.a $(BUILD)/win64/graphics_wrapper_asm.o \
 		$(BUILD)/win64/graphics_wrapper.o $(BUILD)/win64/graphics_support.o \
 		$(BUILD)/win64/graphics_blonde.o $(BUILD)/win64/graph_services.o \
-		$(BUILD)/win64/support.o
+		$(BUILD)/win64/graph_config.o $(BUILD)/win64/support.o
 
 #
 # Gnome widgets for win64, the portable widget set drawn with the graphics API.

--- a/Makefile
+++ b/Makefile
@@ -1031,6 +1031,25 @@ $(BUILD)/win64/cmach_package_min.o: $(SOURCE)/cmach/cmach.c
 # provides the terminal core too, so the graphics flavor links graphics.a (not
 # terminal.a -- they share the ami_* core and cannot co-link).
 cmacht: bin/cmacht
+ifeq ($(HOST),windows)
+# Windows host: build like the standalone win64 cmach.exe (the Ami
+# non-bypass stdio and the win64 external archives), adding the terminal
+# flavor: -DTERMINAL and the win64 terminal archive, which draws through
+# GDI and uses the winmm joystick/timer calls (both in the lib set).
+bin/cmacht: $(SOURCE)/cmach/cmach.c $(SOURCE)/cmach/extern_term.inc \
+		$(LIBS)/win64/services.a $(LIBS)/win64/terminal.a $(LIBS)/win64/sound.a \
+		$(LIBS)/win64/network.a $(BUILD)/win64/cmach_stdio.o
+	@echo
+	@echo "Building cmacht (terminal flavor) for win64..."
+	@echo
+	mkdir -p $(WINCELL)/bin
+	$(WINCC) $(WINCFLAGS) $(CPPFLAGS64LE) -DEXTERNALS -DTERMINAL $(WIN_STDIO_INC) \
+		-o $(BUILD)/win64/cmacht.exe $(SOURCE)/cmach/cmach.c \
+		$(BUILD)/win64/cmach_stdio.o \
+		$(LIBS)/win64/terminal.a $(WINCMACHLIBS) -lgdi32
+	cp $(BUILD)/win64/cmacht.exe $(PASCALP6)/bin/cmacht
+	cp $(BUILD)/win64/cmacht.exe $(WINCELL)/bin/cmacht.exe
+else
 bin/cmacht: $(SOURCE)/cmach/cmach.c $(SOURCE)/cmach/extern_term.inc \
 		$(LIBS)/services.a $(LIBS)/terminal.a $(LIBS)/sound.a $(LIBS)/network.a \
 		$(LIBS)/psystem.a
@@ -1045,6 +1064,7 @@ bin/cmacht: $(SOURCE)/cmach/cmach.c $(SOURCE)/cmach/extern_term.inc \
 	cp $(BUILD)/cmacht64le $(PASCALP6)/bin/cmacht
 	mkdir -p $(HOSTCELL)/bin
 	cp $(BUILD)/cmacht64le $(HOSTCELL)/bin/cmacht
+endif
 
 cmachg: bin/cmachg
 # cmachg hosts a graphics window over the interpreted program like pmachg/pintg,
@@ -1053,6 +1073,25 @@ cmachg: bin/cmachg
 # window at startup; the interpreter keeps its console and vmhost opens the
 # program's window via openwin. The standard libs/graphics.a auto-creates a main
 # window at init, which collides with vmhost's openwin and hangs.
+ifeq ($(HOST),windows)
+# Windows host: like the win64 cmacht above but -DGRAPHICS with the win64
+# "blonde" graphics archive (source/graph/win64). The portable widget
+# package (gnome_widgets) is not linked on windows (native widgets); GDI
+# and the common dialogs take the place of the X11 closure.
+bin/cmachg: $(SOURCE)/cmach/cmach.c $(SOURCE)/cmach/extern_graph.inc \
+		$(LIBS)/win64/services.a source/graph/win64/graphics.a \
+		$(LIBS)/win64/sound.a $(LIBS)/win64/network.a $(BUILD)/win64/cmach_stdio.o
+	@echo
+	@echo "Building cmachg (graphics flavor) for win64..."
+	@echo
+	mkdir -p $(WINCELL)/bin
+	$(WINCC) $(WINCFLAGS) $(CPPFLAGS64LE) -DEXTERNALS -DGRAPHICS $(WIN_STDIO_INC) \
+		-o $(BUILD)/win64/cmachg.exe $(SOURCE)/cmach/cmach.c \
+		$(BUILD)/win64/cmach_stdio.o \
+		source/graph/win64/graphics.a $(WINCMACHLIBS) -lgdi32 -lcomdlg32
+	cp $(BUILD)/win64/cmachg.exe $(PASCALP6)/bin/cmachg
+	cp $(BUILD)/win64/cmachg.exe $(WINCELL)/bin/cmachg.exe
+else
 bin/cmachg: $(SOURCE)/cmach/cmach.c $(SOURCE)/cmach/extern_graph.inc \
 		$(LIBS)/services.a source/graph/graphics.a $(LIBS)/gnome_widgets.o \
 		$(LIBS)/sound.a $(LIBS)/network.a $(LIBS)/psystem.a
@@ -1072,6 +1111,7 @@ bin/cmachg: $(SOURCE)/cmach/cmach.c $(SOURCE)/cmach/extern_graph.inc \
 	cp $(BUILD)/cmachg64le $(PASCALP6)/bin/cmachg
 	mkdir -p $(HOSTCELL)/bin
 	cp $(BUILD)/cmachg64le $(HOSTCELL)/bin/cmachg
+endif
 
 #
 # Build spew, an automated test facillity.

--- a/bin/build
+++ b/bin/build
@@ -11,6 +11,43 @@
 #
 # build "-Bi" "-r -d"
 #
+#
+# Install a built program into bin. bin holds only binaries for the host we
+# are running on: on a windows host the native build product is <prog>.exe,
+# elsewhere the bare <prog>. The selection is by host, never by guessing
+# between candidate files, so a stale bare-named leftover (e.g. a linux
+# binary from an earlier use of the same tree) can never be installed.
+# Cross compiled products (compwin) go only to the hosts tree, never bin.
+# On windows both bin names (<name> and <name>.exe) are written so shell
+# callers and native tool spawns (which require the .exe) both resolve.
+# cygpath exists only on a windows msys/cygwin host, so it detects windows
+# robustly.
+#
+function instprog {
+
+   local src="$1"
+   local dst="$2"
+
+   if [ -d "$dst" ]; then dst="$dst/$(basename $1)"; fi
+   if command -v cygpath >/dev/null 2>&1; then
+
+      if [ ! -f "$1.exe" ]; then
+
+         echo "*** Error: windows build product $1.exe missing"
+         exit 1
+
+      fi
+      cp "$1.exe" "$dst"
+      case "$dst" in *.exe) ;; *) cp "$1.exe" "$dst.exe" ;; esac
+
+   else
+
+      cp "$src" "$dst"
+
+   fi
+
+}
+
 function compprog {
 
    echo ""
@@ -25,7 +62,7 @@ function compprog {
       exit 1
 
    fi
-   cp $1 bin
+   instprog $1 bin
 
 }
 
@@ -188,7 +225,7 @@ cp graph_games/conquest_map.bmp graph_games/slide.wav graph_games/dice.wav bin/
 #
 cp bin/pgen pgen.old
 compprog source/pgen/amd64/pgen
-cp source/pgen/amd64/pgen bin/pgen_amd64
+instprog source/pgen/amd64/pgen bin/pgen_amd64
 cp bin/pgen pgen.new
 cp pgen.old bin/pgen
 compprog source/pcom
@@ -213,7 +250,7 @@ if [ $? -ne 0 ]; then
    exit 1
 
 fi
-cp source/pgen/arm64/pgen bin/pgen_arm64
+instprog source/pgen/arm64/pgen bin/pgen_arm64
 compprog source/pint
 #
 # pintt is the same source built with the terminal module flavor first on
@@ -233,7 +270,7 @@ if [ $? -ne 0 ]; then
    exit 1
 
 fi
-cp source/pint bin/pintt
+instprog source/pint bin/pintt
 #
 # pintg is the graphics-hosted interpreter: the graph flavor links the
 # "blonde" graphics archive (no automatic standard I/O window) and hosts
@@ -251,7 +288,7 @@ if [ $? -ne 0 ]; then
    exit 1
 
 fi
-cp source/pint bin/pintg
+instprog source/pint bin/pintg
 pc source/pint -r $OPTIONS
 if [ $? -ne 0 ]; then
 
@@ -259,7 +296,7 @@ if [ $? -ne 0 ]; then
    exit 1
 
 fi
-cp source/pint bin
+instprog source/pint bin
 compprog source/pmach
 #
 # pmacht and pmachg are the same source built with the terminal and graphics
@@ -278,7 +315,7 @@ if [ $? -ne 0 ]; then
    exit 1
 
 fi
-cp source/pmach bin/pmacht
+instprog source/pmach bin/pmacht
 echo ""
 echo "**********************************************************************"
 echo "Building source/pmach (graphics flavor) as pmachg..."
@@ -291,7 +328,7 @@ if [ $? -ne 0 ]; then
    exit 1
 
 fi
-cp source/pmach bin/pmachg
+instprog source/pmach bin/pmachg
 pc source/pmach -r $OPTIONS
 if [ $? -ne 0 ]; then
 
@@ -299,7 +336,7 @@ if [ $? -ne 0 ]; then
    exit 1
 
 fi
-cp source/pmach bin
+instprog source/pmach bin
 
 #
 # cmacht is the terminal flavor of cmach, the same cmach.c built with -DTERMINAL

--- a/bin/build
+++ b/bin/build
@@ -61,6 +61,20 @@ function compwin {
 
 OPTIONS=$2
 
+#
+# The graph flavor's "blonde" graphics archive is per-target: the linux
+# build keeps it in source/graph itself, the windows build in
+# source/graph/win64 (mirroring the hosts tree layout). Select the target's
+# archive ahead of the flavor sources so the flavored interpreter builds
+# (pintg, pmachg) link the right one. cygpath exists only on a windows
+# msys/cygwin host, so it detects windows robustly.
+#
+if command -v cygpath >/dev/null 2>&1; then
+   GRAPHMP="source/graph/win64;source/graph"
+else
+   GRAPHMP="source/graph"
+fi
+
 make clean
 make $1
 if [ $? -ne 0 ]; then
@@ -230,7 +244,7 @@ echo "**********************************************************************"
 echo "Building source/pint (graphics flavor) as pintg..."
 echo "**********************************************************************"
 echo ""
-pc source/pint -mp=source/graph -r $OPTIONS
+pc source/pint "-mp=$GRAPHMP" -r $OPTIONS
 if [ $? -ne 0 ]; then
 
    echo "*** Error: compile failed"
@@ -270,7 +284,7 @@ echo "**********************************************************************"
 echo "Building source/pmach (graphics flavor) as pmachg..."
 echo "**********************************************************************"
 echo ""
-pc source/pmach -mp=source/graph -r $OPTIONS
+pc source/pmach "-mp=$GRAPHMP" -r $OPTIONS
 if [ $? -ne 0 ]; then
 
    echo "*** Error: compile failed"

--- a/pc/pc.pas
+++ b/pc/pc.pas
@@ -2456,11 +2456,13 @@ begin { dolink }
       fndfil(psystem, true);
       if not exists(psystem) then { not found }
          writeln('*** pc: Error: support module "%"', psystem);
-      if windowed then begin
+      if windowed and not fwindows then begin
 
          { find the widgets module. It overrides the graphics widget stubs from
            a constructor and exports no symbols, so it cannot be force-linked
-           from an archive; it is linked as an explicit object. }
+           from an archive; it is linked as an explicit object. Windows is
+           excluded: its graphics model carries a native widget set, so the
+           portable widget package is not used there. }
          copy(widgets, 'gnome_widgets');
          fndfil(widgets, true);
          if not exists(widgets) then { not found }
@@ -2517,8 +2519,8 @@ begin { dolink }
         the module chain, so a foreign object between main and the modules
         breaks the chain. Its graphics references resolve from the graphics.a
         members the -u anchor has already extracted, and its stdio from
-        psystem, later on the line. }
-      if windowed then begin putstr(widgets); putchr(' ') end;
+        psystem, later on the line. Not linked on windows (native widgets). }
+      if windowed and not fwindows then begin putstr(widgets); putchr(' ') end;
       putstr(psystem);
       putchr(' ');
       putstr('-lm -lpthread');
@@ -2530,19 +2532,21 @@ begin { dolink }
          if fwindows then
             { The Windows graphics model renders through GDI and picks files
               and colors through the common dialogs; user32/kernel32 link
-              implicitly. No X11/FreeType/FontConfig closure. }
-            putstr('-lgdi32 -lcomdlg32')
+              implicitly. No X11/FreeType/FontConfig closure. winmm supplies
+              the joystick calls and the multimedia frame timer. }
+            putstr('-lgdi32 -lcomdlg32 -lwinmm')
          else begin
             putstr('-lXext -lX11 -lpthread -lxcb -lXau -lXdmcp -lfontconfig');
             putchr(' ');
             putstr('-luuid -lexpat -lfreetype -lpng16 -lm -lz -ldl')
          end end;
       { The Windows terminal model draws its console window through GDI, so it
-        needs gdi32 (the linux terminal is self contained). Harmless for a
-        non-terminal program: gdi32 is an import library with nothing pulled in
-        unless referenced. The graphics case already carries gdi32 above. }
+        needs gdi32 (the linux terminal is self contained), and winmm for the
+        joystick calls and the multimedia frame timer. Harmless for a
+        non-terminal program: they are import libraries with nothing pulled in
+        unless referenced. The graphics case already carries both above. }
       if terminaled and fwindows and not windowed then begin putchr(' ');
-         putstr('-lgdi32') end;
+         putstr('-lgdi32 -lwinmm') end;
       { The sound library plays through ALSA and synthesizes through
         fluidsynth (whose closure adds glib and pcre). The static libasound
         and libfluidsynth are locally built and installed in /usr/local/lib


### PR DESCRIPTION
## Problem

`build -B -r` on windows stopped at `graphics_test`: every graphics program failed to link with 112 undefined symbols. After fixing that, the flavored interpreter phases (pintg/pmachg, then cmacht/cmachg) failed next.

## Causes and fixes

**Commit 1 — the graphics program link:**
1. **Missing config.o in the win64 graphics archives.** The linux graphics archive carries `config.o` (`amitk/utils/config.c`); the win64 archives omitted it, leaving the windows graphics init's `ami_config`/`ami_schlst` unresolved. Added `graph_config.o` to both the standard and blonde win64 graphics archives (Makefile).
2. **gnome_widgets linked on windows.** pc linked the portable widget package on every windowed target. Windows carries its own native widget set, and the portable package's override vector set (`_pa_*_ovr`, 88 symbols) does not exist in the windows graphics model. Linked only on non-windows targets now (pc.pas).
3. **Missing `-lwinmm`.** The windows graphics and terminal models use winmm (joystick calls, multimedia frame timer). Added to the windowed and terminal windows link lines (pc.pas).

**Commit 2 — the flavored interpreters:**
4. **pintg/pmachg linked the stale linux blonde archive.** The graph flavor's blonde graphics archive is per-target: `source/graph` (linux) vs `source/graph/win64` (windows, mirroring the hosts tree). `bin/build` now selects the target's archive ahead of the flavor sources (`-mp="source/graph/win64;source/graph"` on windows); previously the windows build linked the linux archive and failed with mangled-symbol undefines from extexec.
5. **cmacht/cmachg had linux-only rules** (`$(CC)`, ALSA/X11 closure). Added windows host rules built like the standalone win64 cmach.exe (Ami non-bypass stdio, win64 external archives) plus the flavor: `-DTERMINAL` + win64 terminal.a + gdi32, or `-DGRAPHICS` + win64 blonde + gdi32/comdlg32. Linux rules unchanged.

The remaining 19 `ami_*` calls are completed on the amitk side — **samiam95124/amitk#137**. The amitk submodule pointer bump follows once #137 merges.

## Verification (on windows)

- All **19 programs** in the build script link clean: graphics_test, widget_test, terminal_test, management_test, all 7 graph games, sound/network/services tests — 0 undefined references.
- **pintg, pmachg, cmacht, cmachg** all build and link clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA