### PR TITLE
support: win64 variants of pacall and the callback thunk

### DIFF
--- a/libs/source/support.c
+++ b/libs/source/support.c
@@ -145,6 +145,27 @@ __asm__ (
 "    ret\n"
 );
 
+#elif defined(_WIN32)
+
+/* Windows x64: the C caller enters with (code=%rcx, display=%rdx, arg=%r8)
+   per the win64 convention, and the Pascaline side uses the same convention
+   (parameter 1 in %rcx) with the display carried in %rbp as on SysV. The
+   win64 shadow space is allocated for the callee. */
+__asm__ (
+"    .text\n"
+"    .globl pacall\n"
+"pacall:\n"                 /* void pacall(code=%rcx, display=%rdx, arg=%r8) */
+"    push %rbp\n"           /* preserve C frame pointer */
+"    mov  %rcx, %rax\n"     /* %rax = code address */
+"    mov  %rdx, %rbp\n"     /* %rbp = display (static link) */
+"    mov  %r8,  %rcx\n"     /* %rcx = argument (Pascaline param 1) */
+"    sub  $32, %rsp\n"      /* win64 shadow space */
+"    call *%rax\n"          /* enter the Pascaline procedure */
+"    add  $32, %rsp\n"
+"    pop  %rbp\n"           /* restore C frame pointer */
+"    ret\n"
+);
+
 #else
 
 __asm__ (
@@ -221,6 +242,33 @@ void* mkevtthunk(void* code, void* display, void* dispatch)
     lit[1] = display;
     lit[2] = dispatch;
     __builtin___clear_cache((char*)t, (char*)(t+THUNKSZ));
+
+    return t;
+}
+
+#elif defined(_WIN32)
+
+/* emit a movabs of a 64 bit immediate into a register (opcode selects reg) */
+static unsigned char* emitimm(unsigned char* p, unsigned char op, void* val)
+{
+    *p++ = 0x48; *p++ = op;
+    memcpy(p, &val, 8);
+    return p+8;
+}
+
+/* build a thunk: void thunk(void* arg) -> dispatch(code, display, arg).
+   Windows x64 convention: the incoming argument is in %rcx and the
+   dispatcher takes (code=%rcx, display=%rdx, arg=%r8). */
+void* mkevtthunk(void* code, void* display, void* dispatch)
+{
+    unsigned char* t = thunkalloc();
+    unsigned char* p = t;
+
+    *p++ = 0x49; *p++ = 0x89; *p++ = 0xc8;   /* mov  %rcx,%r8   (arg -> arg3) */
+    p = emitimm(p, 0xba, display);           /* movabs display,%rdx (arg2)    */
+    p = emitimm(p, 0xb9, code);              /* movabs code,%rcx    (arg1)    */
+    p = emitimm(p, 0xb8, dispatch);          /* movabs dispatch,%rax          */
+    *p++ = 0xff; *p++ = 0xe0;                /* jmp  *%rax                    */
 
     return t;
 }


### PR DESCRIPTION
## Problem

Seen live in `terminal_test`'s **Event vector test** on Windows: `*** Event bled through! ***` — an installed frame-event override ran (its flag side effects landed, so "Fanout/Master event passes" printed) but the intercepted event was **also** returned to the main event loop.

## Root cause

`pacall` (enter a Pascaline procedure from C) and `mkevtthunk` (present a Pascaline procedure as a plain C callback pointer) in `libs/source/support.c` are hand-written x86-64 machine code targeting the **SysV** convention — arguments in `%rdi/%rsi/%rdx`. On Windows both the C side (mingw) and the Pascaline side (pgen win64) use the **win64** convention — `%rcx/%rdx/%r8`. When ami invoked an event-override thunk, the registers were scrambled: the handler happened to execute (visible side effects worked by accident), but the event-record pointer and the `handled` round-trip were lost — so the C dispatch saw the event as unhandled and returned it to the caller.

## Fix

Win64 variants under `#elif defined(_WIN32)`:
- **thunk**: maps the single `%rcx` argument to the dispatcher's `(code=%rcx, display=%rdx, arg=%r8)`;
- **pacall**: enters the Pascaline procedure with the argument in `%rcx`, the display in `%rbp` (the display register in both conventions), and the win64 shadow space allocated.

SysV and arm64 variants unchanged.

## Verification

Native C harnesses on Windows:
- thunk called with win64 ABI → dispatcher received code/display/arg all **exact** (`calls=1, arg-ok=1`);
- `pacall` → win64 procedure entered with the argument register correct (`calls=1, arg-ok=1`).

win64 `support.o` rebuilt into services/terminal/graphics (+blonde) archives and hosts tree; `terminal_test` rebuilt for an interactive re-run of the event vector test. Interpreters embedding these archives (pintt/pintg/pmacht/pmachg/cmacht/cmachg) pick up the fix on the next `build -B -r`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA