### PR TITLE
pgen: split a parameter pair across the win64 register/stack boundary

### DIFF
--- a/source/pgen/amd64/pgen.pas
+++ b/source/pgen/amd64/pgen.pas
@@ -267,6 +267,12 @@ override procedure assemble; (*translate symbolic code into machine code and sto
         if pc <= maxintparregw-1 then begin
           resreg(parregw[pc]); resreg(parregw[pc+1]);
           assreg(pp, rf, parregw[pc], parregw[pc+1])
+        end else if pc = maxintparregw then begin
+          { the pair straddles the register/stack boundary: the first half
+            takes the last register slot, the second half overflows to the
+            stack (the callee sees them as two positional parameters) }
+          resreg(parregw[pc]); getreg(r2, rf);
+          assreg(pp, rf, parregw[pc], r2)
         end else begin
           getreg(r1, rf); getreg(r2, rf); assreg(pp, rf, r1, r2)
         end;
@@ -1108,31 +1114,37 @@ override procedure assemble; (*translate symbolic code into machine code and sto
 
     { recursively traverse list to process overflow params right-to-left }
     procedure pshovfw(p: expptr; var pc: integer);
-    var stk: boolean;
+    var stk, strad: boolean;
     begin
       if p <> nil then begin
         pshovfw(p^.next, pc); { recurse to end first }
         { now processing right-to-left }
+        strad := false;
         if isfltres(p) then begin
           pc := pc-1; stk := pc >= maxfltparregw
         end else if instab[p^.op].insr = 2 then begin
-          pc := pc-2; stk := pc >= maxintparregw-1
+          pc := pc-2; stk := pc >= maxintparregw;
+          { a pair whose first half takes the last register slot straddles
+            the boundary: only its second half goes to the stack }
+          strad := pc = maxintparregw-1
         end else begin
           pc := pc-1; stk := pc >= maxintparregw
         end;
-        if stk then begin
+        if stk or strad then begin
           genexp(p);
           if p^.r2 <> rgnull then begin
             wrtins(' pushq %1 # place 2nd register on stack', p^.r2);
             stkadr := stkadr-intsize
           end;
-          if p^.r1 in [rgrax..rgr15] then begin
-            wrtins(' pushq %1 # save parameter', p^.r1);
-            stkadr := stkadr-intsize
-          end else if p^.r1 in [rgxmm0..rgxmm15] then begin
-            wrtins(' subq $0,%rsp # allocate real on stack', realsize);
-            stkadr := stkadr-realsize;
-            wrtins(' movsd %1,(%rsp) # place real on stack', p^.r1)
+          if stk then begin
+            if p^.r1 in [rgrax..rgr15] then begin
+              wrtins(' pushq %1 # save parameter', p^.r1);
+              stkadr := stkadr-intsize
+            end else if p^.r1 in [rgxmm0..rgxmm15] then begin
+              wrtins(' subq $0,%rsp # allocate real on stack', realsize);
+              stkadr := stkadr-realsize;
+              wrtins(' movsd %1,(%rsp) # place real on stack', p^.r1)
+            end
           end
         end
       end
@@ -1206,7 +1218,10 @@ override procedure assemble; (*translate symbolic code into machine code and sto
       end else begin
         if instab[p^.op].insr = 2 then begin
           pc := pc + 2;
-          if pc > maxintparregw then sz := sz + intsize * 2
+          { a pair ending at maxintparregw+1 straddles the boundary: only
+            its second half occupies the stack }
+          if pc > maxintparregw+1 then sz := sz + intsize * 2
+          else if pc = maxintparregw+1 then sz := sz + intsize
         end else begin
           pc := pc + 1;
           if pc > maxintparregw then sz := sz + intsize


### PR DESCRIPTION
## Problem

`chess` segfaulted instantly at startup on Windows, in `load_pieces` → `wrapper_maknamppss` → `rempad`.

## Root cause

pgen's Windows x64 parameter assignment treated a two-register parameter (a string's (pointer,length) pair) as **all-or-nothing**: both halves in registers if two slots remained, otherwise the whole pair to the stack. The MS convention has no such rule — the C callee sees the pair as two positional parameters, so a pair starting in the **last** register slot must split: first half in R9, second half on the stack.

The failing call `maknam(getpgm, 'chess_pieces', '')` marshals as 5 slots: `p`(1)=RCX, `n`(2)=RDX, `nl`(3)=R8, `e`(4)=R9, `el`(5)=stack. pgen put the `e/el` pair entirely on the stack and never loaded R9 — so the C wrapper read `e` = garbage R9 and `el` = the low 32 bits of the `e` pointer it found in the wrong stack slot (confirmed exactly in the crash backtrace), then faulted trimming pad from the garbage string.

## Fix

The three places sharing the slot accounting, kept consistent:
- **assparw** — a straddling pair gets the last parameter register + a scratch register for the overflow half;
- **pshovfw** — a straddle pushes only the second half;
- **cmpparmspcw** — counts one stack word (not two) for a straddle, keeping the alignment check and the post-call `addq` cleanup consistent with the pushes.

## Verification (on Windows, rebuilt pgen)

- minimal `maknam(getpgm, 'chess_pieces', '')` repro: was segfault → now returns the correct path;
- **chess starts and runs** (window up);
- pgen sanity: iso7185pat, qsort, startrek compile + run, **0 diffs** vs goldens.

## Note

The SysV path has the same all-or-nothing logic at its 6-register boundary (`asspar`/`pshovf`/`cmpparmspc`) — a straddling pair there (e.g. the 4-argument `maknam` procedure form, 7 slots) would misplace parameters the same way. Left untouched pending a Linux-tested follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA