### PR TITLE
management_test: keep the tested title visible during the titling test

### DIFF
--- a/libs/tests/management_test.pas
+++ b/libs/tests/management_test.pas
@@ -357,7 +357,10 @@ begin
    title(output, 'This is a mangement test window');
    writeln('The title bar of this window should read: This is a mangement test window');
    prtceng(maxyg(output)-chrsizy(output), 'Window title test');
-   waitnext;
+   { wait directly: waitnext retitles the window with the frame number, which
+     would overwrite the very title this test displays for verification }
+   repeat event(input, er) until (er.etype = etenter) or (er.etype = etterm);
+   if er.etype = etterm then goto 99;
 
    { ************************** Multiple windows ************************** }
 


### PR DESCRIPTION
## Problem

The window titling test sets `title(output, 'This is a mangement test window')` and asks the operator to verify the title bar — then immediately waits via `waitnext`, which **retitles the window with the frame counter before waiting**. The tested title is overwritten in the same instant it was set, so it was never observable (on any platform — the same code runs on linux).

The title machinery itself is fine: the advancing `management_test: frame N` counter in the bar is itself a continuous demonstration that `title()` works.

## Fix

Wait with a plain event loop (enter/terminate) for this one test, so the tested title stays on the bar until the operator continues. `waitnext` and its frame counter are unchanged everywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA