### PR TITLE
Revert #570; reform straddling pairs in the wrappers instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,8 @@ $(LIBS)/win64/services.a: $(PASCALP6)/amitk/windows/services.c \
 		-o $(BUILD)/win64/support.o -c $(LIBS)/source/support.c
 	$(WINCC) $(WINCFLAGS) $(WINSERVCPP) \
 		-o $(BUILD)/win64/services_support.o -c $(LIBS)/source/services_support.c
-	$(WINCC) $(WINCFLAGS) $(CPPFLAGS64LE) -o $(BUILD)/win64/services_wrapper_asm.o \
+	$(WINCC) $(WINCFLAGS) $(CPPFLAGS64LE) -Wa,--defsym,WINDOWS=1 \
+		-o $(BUILD)/win64/services_wrapper_asm.o \
 		-c -x assembler $(LIBS)/source/services_wrapper.asm
 	$(WINCC) $(WINCFLAGS) $(WINSERVCPP) \
 		-o $(BUILD)/win64/services_wrapper.o -c $(LIBS)/source/services_wrapper.c
@@ -386,7 +387,8 @@ $(LIBS)/win64/terminal.a: $(AMIWIN)/terminal.c \
 		-o $(BUILD)/win64/support.o -c $(LIBS)/source/support.c
 	$(WINCC) $(WINCFLAGS) $(WINTERMCPP) \
 		-o $(BUILD)/win64/terminal_support.o -c $(LIBS)/source/terminal_support.c
-	$(WINCC) $(WINCFLAGS) $(CPPFLAGS64LE) -o $(BUILD)/win64/terminal_wrapper_asm.o \
+	$(WINCC) $(WINCFLAGS) $(CPPFLAGS64LE) -Wa,--defsym,WINDOWS=1 \
+		-o $(BUILD)/win64/terminal_wrapper_asm.o \
 		-c -x assembler $(LIBS)/source/terminal_wrapper.asm
 	$(WINCC) $(WINCFLAGS) $(WINTERMCPP) \
 		-o $(BUILD)/win64/terminal_wrapper.o -c $(LIBS)/source/terminal_wrapper.c
@@ -428,7 +430,8 @@ $(LIBS)/win64/graphics.a: $(AMIWIN)/graphics.c \
 		-o $(BUILD)/win64/support.o -c $(LIBS)/source/support.c
 	$(WINCC) $(WINCFLAGS) $(WINGRAPHCPP) \
 		-o $(BUILD)/win64/graphics_support.o -c $(LIBS)/source/graphics_support.c
-	$(WINCC) $(WINCFLAGS) $(CPPFLAGS64LE) -o $(BUILD)/win64/graphics_wrapper_asm.o \
+	$(WINCC) $(WINCFLAGS) $(CPPFLAGS64LE) -Wa,--defsym,WINDOWS=1 \
+		-o $(BUILD)/win64/graphics_wrapper_asm.o \
 		-c -x assembler $(LIBS)/source/graphics_wrapper.asm
 	$(WINCC) $(WINCFLAGS) $(WINGRAPHCPP) \
 		-o $(BUILD)/win64/graphics_wrapper.o -c $(LIBS)/source/graphics_wrapper.c
@@ -498,7 +501,8 @@ $(LIBS)/win64/sound.a: $(AMIWIN)/sound.c \
 	mkdir -p $(LIBS)/win64
 	$(WINCC) $(WINCFLAGS) $(WINSNDNETCPP) \
 		-o $(BUILD)/win64/snd_support.o -c $(LIBS)/source/support.c
-	$(WINCC) $(WINCFLAGS) $(CPPFLAGS64LE) -o $(BUILD)/win64/sound_wrapper_asm.o \
+	$(WINCC) $(WINCFLAGS) $(CPPFLAGS64LE) -Wa,--defsym,WINDOWS=1 \
+		-o $(BUILD)/win64/sound_wrapper_asm.o \
 		-c -x assembler $(LIBS)/source/sound_wrapper.asm
 	$(WINCC) $(WINCFLAGS) $(WINSNDNETCPP) \
 		-o $(BUILD)/win64/sound_wrapper.o -c $(LIBS)/source/sound_wrapper.c
@@ -524,7 +528,8 @@ $(LIBS)/win64/network.a: $(AMIWIN)/network.c \
 	mkdir -p $(LIBS)/win64
 	$(WINCC) $(WINCFLAGS) $(WINSNDNETCPP) \
 		-o $(BUILD)/win64/net_support.o -c $(LIBS)/source/support.c
-	$(WINCC) $(WINCFLAGS) $(CPPFLAGS64LE) -o $(BUILD)/win64/network_wrapper_asm.o \
+	$(WINCC) $(WINCFLAGS) $(CPPFLAGS64LE) -Wa,--defsym,WINDOWS=1 \
+		-o $(BUILD)/win64/network_wrapper_asm.o \
 		-c -x assembler $(LIBS)/source/network_wrapper.asm
 	$(WINCC) $(WINCFLAGS) $(WINSNDNETCPP) \
 		-o $(BUILD)/win64/network_wrapper.o -c $(LIBS)/source/network_wrapper.c

--- a/libs/source/services_wrapper.asm
+++ b/libs/source/services_wrapper.asm
@@ -331,12 +331,22 @@ services.maknam$f_vc_vc_vc:
 # function maknam(view p: string; view n: string; e: pstring): pstring; external;
 
 services.maknam$f_vc_vc_pvc:
-    jmp     wrapper_maknamppsp
+    jmp     wrapper_maknampssp
 
 # function maknam(view p: string; n: pstring; view e: string): pstring; external;
+#
+# The e string pair starts at parameter slot 4. The Pascaline convention
+# keeps a pair whole, so the caller passes it entirely on the stack; the
+# windows C convention splits it, slot 4 in r9 and slot 5 on the stack.
+# Reform: pull the pointer half into r9 and shift the length half down.
 
 services.maknam$f_vc_pvc_vc:
-    jmp     wrapper_maknamppsp
+.ifdef WINDOWS
+    movq    0x28(%rsp),%r9          # e: whole stacked pair -> C slot 4
+    movq    0x30(%rsp),%rax         # el: shift down one slot
+    movq    %rax,0x28(%rsp)
+.endif
+    jmp     wrapper_maknampsps
 
 # function maknam(view p: string; n: pstring; e: pstring): pstring; external;
 
@@ -344,8 +354,16 @@ services.maknam$f_vc_pvc_pvc:
     jmp     wrapper_maknampspp
 
 # function maknam(p: pstring; view n: string; view e: string): pstring; external;
+#
+# The e string pair starts at parameter slot 4: reform for windows, as in
+# maknam$f_vc_pvc_vc above.
 
 services.maknam$f_pvc_vc_vc:
+.ifdef WINDOWS
+    movq    0x28(%rsp),%r9          # e: whole stacked pair -> C slot 4
+    movq    0x30(%rsp),%rax         # el: shift down one slot
+    movq    %rax,0x28(%rsp)
+.endif
     jmp     wrapper_maknamppss
 
 # function maknam(p: pstring; view n: string; e: pstring): pstring; external;

--- a/libs/source/services_wrapper.c
+++ b/libs/source/services_wrapper.c
@@ -1008,24 +1008,23 @@ void ami_maknam(char* fn, int fnl, char* p, char* n, char* e);
 ********************************************************************************/
 
 pstring wrapper_maknampssp(
-    /** string pointer */ pstring p,
-    /** string pointer */ string n,
-    /** string length */  int nl,
+    /** string pointer */ string  p,
+    /** string length */  int     pl,
+    /** string pointer */ string  n,
+    /** string length */  int     nl,
     /** string pointer */ pstring e
 )
 
 {
 
-    string ps;
-    int    pl;
     string es;
     int    el;
     char buff[BUFLEN];
 
-    pstr2cstrl(p, &ps, &pl); /* get cstr/len from pstring */
+    rempad(p, &pl); /* remove padding */
     rempad(n, &nl); /* remove padding */
     pstr2cstrl(e, &es, &el); /* get cstr/len from pstring */
-    ami_maknam(buff, BUFLEN, cstrz(ps, pl), cstrz(n, nl), cstrz(es, el));
+    ami_maknam(buff, BUFLEN, cstrz(p, pl), cstrz(n, nl), cstrz(es, el));
 
     return (cstr2pstr(buff, BUFLEN)); /* return pstring */
 

--- a/libs/source/sound_wrapper.asm
+++ b/libs/source/sound_wrapper.asm
@@ -141,15 +141,35 @@ sound.fltwaveout$p_i_i:
     jmp     wrapper_fltwaveout
 
 sound.getparamsynthin$p_i_vc_vc:
+.ifdef WINDOWS
+    movq    0x28(%rsp),%r9          # value: whole stacked pair -> C slot 4
+    movq    0x30(%rsp),%rax         # length: shift down one slot
+    movq    %rax,0x28(%rsp)
+.endif
     jmp     wrapper_getparamsynthin
 
 sound.getparamsynthout$p_i_vc_vc:
+.ifdef WINDOWS
+    movq    0x28(%rsp),%r9          # value: whole stacked pair -> C slot 4
+    movq    0x30(%rsp),%rax         # length: shift down one slot
+    movq    %rax,0x28(%rsp)
+.endif
     jmp     wrapper_getparamsynthout
 
 sound.getparamwavein$p_i_vc_vc:
+.ifdef WINDOWS
+    movq    0x28(%rsp),%r9          # value: whole stacked pair -> C slot 4
+    movq    0x30(%rsp),%rax         # length: shift down one slot
+    movq    %rax,0x28(%rsp)
+.endif
     jmp     wrapper_getparamwavein
 
 sound.getparamwaveout$p_i_vc_vc:
+.ifdef WINDOWS
+    movq    0x28(%rsp),%r9          # value: whole stacked pair -> C slot 4
+    movq    0x30(%rsp),%rax         # length: shift down one slot
+    movq    %rax,0x28(%rsp)
+.endif
     jmp     wrapper_getparamwaveout
 
 sound.instchange$p_i_i_x$1$16$i_x$1$128$i:
@@ -237,15 +257,35 @@ sound.reverb$p_i_i_x$1$16$i_i:
     jmp     wrapper_reverb
 
 sound.setparamsynthin$f_i_vc_vc:
+.ifdef WINDOWS
+    movq    0x28(%rsp),%r9          # value: whole stacked pair -> C slot 4
+    movq    0x30(%rsp),%rax         # length: shift down one slot
+    movq    %rax,0x28(%rsp)
+.endif
     jmp     wrapper_setparamsynthin
 
 sound.setparamsynthout$f_i_vc_vc:
+.ifdef WINDOWS
+    movq    0x28(%rsp),%r9          # value: whole stacked pair -> C slot 4
+    movq    0x30(%rsp),%rax         # length: shift down one slot
+    movq    %rax,0x28(%rsp)
+.endif
     jmp     wrapper_setparamsynthout
 
 sound.setparamwavein$f_i_vc_vc:
+.ifdef WINDOWS
+    movq    0x28(%rsp),%r9          # value: whole stacked pair -> C slot 4
+    movq    0x30(%rsp),%rax         # length: shift down one slot
+    movq    %rax,0x28(%rsp)
+.endif
     jmp     wrapper_setparamwavein
 
 sound.setparamwaveout$f_i_vc_vc:
+.ifdef WINDOWS
+    movq    0x28(%rsp),%r9          # value: whole stacked pair -> C slot 4
+    movq    0x30(%rsp),%rax         # length: shift down one slot
+    movq    %rax,0x28(%rsp)
+.endif
     jmp     wrapper_setparamwaveout
 
 sound.sgnwavein$f_i:

--- a/source/pgen/amd64/pgen.pas
+++ b/source/pgen/amd64/pgen.pas
@@ -267,12 +267,6 @@ override procedure assemble; (*translate symbolic code into machine code and sto
         if pc <= maxintparregw-1 then begin
           resreg(parregw[pc]); resreg(parregw[pc+1]);
           assreg(pp, rf, parregw[pc], parregw[pc+1])
-        end else if pc = maxintparregw then begin
-          { the pair straddles the register/stack boundary: the first half
-            takes the last register slot, the second half overflows to the
-            stack (the callee sees them as two positional parameters) }
-          resreg(parregw[pc]); getreg(r2, rf);
-          assreg(pp, rf, parregw[pc], r2)
         end else begin
           getreg(r1, rf); getreg(r2, rf); assreg(pp, rf, r1, r2)
         end;
@@ -1114,37 +1108,31 @@ override procedure assemble; (*translate symbolic code into machine code and sto
 
     { recursively traverse list to process overflow params right-to-left }
     procedure pshovfw(p: expptr; var pc: integer);
-    var stk, strad: boolean;
+    var stk: boolean;
     begin
       if p <> nil then begin
         pshovfw(p^.next, pc); { recurse to end first }
         { now processing right-to-left }
-        strad := false;
         if isfltres(p) then begin
           pc := pc-1; stk := pc >= maxfltparregw
         end else if instab[p^.op].insr = 2 then begin
-          pc := pc-2; stk := pc >= maxintparregw;
-          { a pair whose first half takes the last register slot straddles
-            the boundary: only its second half goes to the stack }
-          strad := pc = maxintparregw-1
+          pc := pc-2; stk := pc >= maxintparregw-1
         end else begin
           pc := pc-1; stk := pc >= maxintparregw
         end;
-        if stk or strad then begin
+        if stk then begin
           genexp(p);
           if p^.r2 <> rgnull then begin
             wrtins(' pushq %1 # place 2nd register on stack', p^.r2);
             stkadr := stkadr-intsize
           end;
-          if stk then begin
-            if p^.r1 in [rgrax..rgr15] then begin
-              wrtins(' pushq %1 # save parameter', p^.r1);
-              stkadr := stkadr-intsize
-            end else if p^.r1 in [rgxmm0..rgxmm15] then begin
-              wrtins(' subq $0,%rsp # allocate real on stack', realsize);
-              stkadr := stkadr-realsize;
-              wrtins(' movsd %1,(%rsp) # place real on stack', p^.r1)
-            end
+          if p^.r1 in [rgrax..rgr15] then begin
+            wrtins(' pushq %1 # save parameter', p^.r1);
+            stkadr := stkadr-intsize
+          end else if p^.r1 in [rgxmm0..rgxmm15] then begin
+            wrtins(' subq $0,%rsp # allocate real on stack', realsize);
+            stkadr := stkadr-realsize;
+            wrtins(' movsd %1,(%rsp) # place real on stack', p^.r1)
           end
         end
       end
@@ -1218,10 +1206,7 @@ override procedure assemble; (*translate symbolic code into machine code and sto
       end else begin
         if instab[p^.op].insr = 2 then begin
           pc := pc + 2;
-          { a pair ending at maxintparregw+1 straddles the boundary: only
-            its second half occupies the stack }
-          if pc > maxintparregw+1 then sz := sz + intsize * 2
-          else if pc = maxintparregw+1 then sz := sz + intsize
+          if pc > maxintparregw then sz := sz + intsize * 2
         end else begin
           pc := pc + 1;
           if pc > maxintparregw then sz := sz + intsize


### PR DESCRIPTION
## The design ruling

The Pascaline win64 convention keeps a (pointer,length) string pair **whole** — both halves in registers or both on the stack (the callee's parameter save area depends on multi-slot adjacency). The windows C convention has no pair construct: the callee sees two positional parameters, so a pair starting in the last register slot is **split** (pointer in r9, length on the stack). Adapting between conventions is the **wrapper's job** — not the code generator's.

## Commit 1 — revert #570

#570 made pgen split straddling pairs globally, which fixed Pascal→C calls but **broke Pascal→Pascal calls** (callee adjacency invariant). Its first self-hosted rebuild produced a pcom emitting corrupt intermediates — the 9-fail regression and a cascade of downstream damage. Reverted; pgen is pure Pascaline convention again.

## Commit 2 — the correct fix: wrapper reformation

Swept all five bindings (**748 wrapper entries**): the Pascaline and C layouts coincide everywhere **except a pair starting at slot 4** — exactly **10 entries**:
- `services.maknam$f_pvc_vc_vc` (the chess crash) and `maknam$f_vc_pvc_vc`
- the eight `sound.get/setparam{synth,wave}{in,out}` entries

Each now reforms under `.ifdef WINDOWS` (3 instructions: pointer half → r9, length half shifted down one slot); plain `jmp` otherwise. SysV unchanged — no current signature straddles its 6-register boundary. The win64 wrapper-asm recipes assemble with `--defsym WINDOWS=1` (as psystem.asm already did).

Latent bugs found by the sweep, also fixed: two maknam entries jumped to the wrong C variant, and `wrapper_maknampssp`'s signature didn't match its own name/doc (all in so-far-unused variants).

## Verification (windows, pre-#570 pgen + reformed wrappers)

- maknam straddle repro: correct path returned
- **chess starts and runs**
- iso7185pat, qsort, startrek: 0 diffs
- services_test, strings_test: build and run natively

Still open (separate): the bin/build pgen/pcom matched-set juggle swaps only the bare name — needs instprog-aware juggling so a mismatched generator can't build pcom again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA