### PR TITLE
management_test: track the parent only in the stacking resize tests

### DIFF
--- a/libs/tests/management_test.pas
+++ b/libs/tests/management_test.pas
@@ -1094,7 +1094,10 @@ begin
    repeat
 
       event(input, er);
-      if (er.etype = etredraw) or (er.etype = etresize) then begin
+      if ((er.etype = etredraw) or (er.etype = etresize)) and
+         (er.winid = 1) then begin { parent window only: a child resize (native
+                                     sizing borders) must not retrigger the
+                                     parent-tracking resize of the children }
 
          page;
          prtceng(maxyg(output)-chrsizy(output),
@@ -1150,7 +1153,10 @@ begin
    repeat
 
       event(input, er);
-      if (er.etype = etredraw) or (er.etype = etresize) then begin
+      if ((er.etype = etredraw) or (er.etype = etresize)) and
+         (er.winid = 1) then begin { parent window only: a child resize (native
+                                     sizing borders) must not retrigger the
+                                     parent-tracking resize of the children }
 
          page;
          prtceng(maxyg(output)-chrsizy(output),
@@ -1187,7 +1193,10 @@ begin
    repeat
 
       event(input, er); { get next event }
-      if (er.etype = etredraw) or (er.etype = etresize) then begin
+      if ((er.etype = etredraw) or (er.etype = etresize)) and
+         (er.winid = 1) then begin { parent window only: a child resize (native
+                                     sizing borders) must not retrigger the
+                                     parent-tracking resize of the children }
 
          { clear screen without overwriting frame }
          fcolor(output, white);

--- a/libs/tests/management_test.pas
+++ b/libs/tests/management_test.pas
@@ -1095,17 +1095,23 @@ begin
 
       event(input, er);
       if ((er.etype = etredraw) or (er.etype = etresize)) and
-         (er.winid = 1) then begin { parent window only: a child resize (native
-                                     sizing borders) must not retrigger the
-                                     parent-tracking resize of the children }
+         (er.winid = 1) then begin { parent window only }
 
          page;
          prtceng(maxyg(output)-chrsizy(output),
                  'Child windows stacking resize test pixel 1');
          prtceng(1, 'move and resize');
-         setsizg(win3, maxxg(output)-xs*2, maxyg(output)-ys*2);
-         setsizg(win4, maxxg(output)-xs*2, maxyg(output)-ys*2);
-         setsizg(win2, maxxg(output)-xs*2, maxyg(output)-ys*2)
+         { Re-track the children only when the parent is resized. A redraw
+           must not: interactively resizing a child (native sizing borders)
+           uncovers parent area and generates parent redraws, which would
+           snap the child back to the tracked size while it is dragged. }
+         if er.etype = etresize then begin
+
+            setsizg(win3, maxxg(output)-xs*2, maxyg(output)-ys*2);
+            setsizg(win4, maxxg(output)-xs*2, maxyg(output)-ys*2);
+            setsizg(win2, maxxg(output)-xs*2, maxyg(output)-ys*2)
+
+         end
 
       end;
       if er.etype = etterm then goto 99
@@ -1154,17 +1160,21 @@ begin
 
       event(input, er);
       if ((er.etype = etredraw) or (er.etype = etresize)) and
-         (er.winid = 1) then begin { parent window only: a child resize (native
-                                     sizing borders) must not retrigger the
-                                     parent-tracking resize of the children }
+         (er.winid = 1) then begin { parent window only }
 
          page;
          prtceng(maxyg(output)-chrsizy(output),
                  'Child windows stacking resize test pixel 2');
          prtceng(1, 'move and resize');
-         setsizg(win2, maxxg(output)-xs*1*2, maxyg(output)-ys*1*2);
-         setsizg(win3, maxxg(output)-xs*2*2, maxyg(output)-ys*2*2);
-         setsizg(win4, maxxg(output)-xs*3*2, maxyg(output)-ys*3*2)
+         { re-track the children only when the parent is resized (see the
+           pixel 1 test above) }
+         if er.etype = etresize then begin
+
+            setsizg(win2, maxxg(output)-xs*1*2, maxyg(output)-ys*1*2);
+            setsizg(win3, maxxg(output)-xs*2*2, maxyg(output)-ys*2*2);
+            setsizg(win4, maxxg(output)-xs*3*2, maxyg(output)-ys*3*2)
+
+         end
 
       end;
       if er.etype = etterm then goto 99


### PR DESCRIPTION
Found at frame 28: interactively resizing child window 3 by its border made it fight the mouse and flicker back to its old geometry.

The stacking resize tests set the children's sizes from the parent whenever **any** resize event arrives, without checking the event's window. On windows, child windows carry native sizing borders (MDI-style — the OS does child geometry), so dragging a child's border generates resize events *for that child* — and the handler instantly re-imposes the parent-derived size. The parent-tracking logic is only meant to run when the **parent** resizes.

Filter the three stacking loops to `er.winid = 1` — the same idiom the test already uses in its enter-key waits. Children can now be hand-resized freely; resizing the parent still re-tracks all children.

(On linux this never surfaced: X11 child windows carry no interactive sizing decorations, so the fighting path can't trigger.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA