### PR TITLE
wrappers: reform value set parameters to the windows C convention

### DIFF
--- a/libs/source/graphics_wrapper.asm
+++ b/libs/source/graphics_wrapper.asm
@@ -1768,16 +1768,41 @@ graphics.viewscale$p_fc_n_n:
 graphics.viewscale$p_n_n:
     jmp     wrapper_viewscale
 
+# The mode set parameter is a value set. The windows Pascaline convention
+# passes a set by reference, but the C wrappers take the set value as a
+# plain word: reform by dereferencing the set pointer in its slot. (The
+# SysV convention passes the set value directly, so no reform there.)
+
 graphics.winclient$p_fc_i_i_i_i_sx$wmframe$wmsize$wmsysbar$:
+.ifdef WINDOWS
+    movq    0x30(%rsp),%rax         # ms: set pointer in stack slot 6
+    movq    (%rax),%rax             # fetch the set value word
+    movq    %rax,0x30(%rsp)
+.endif
     jmp     wrapper_winclientf
 
 graphics.winclient$p_i_i_i_i_sx$wmframe$wmsize$wmsysbar$:
+.ifdef WINDOWS
+    movq    0x28(%rsp),%rax         # ms: set pointer in stack slot 5
+    movq    (%rax),%rax             # fetch the set value word
+    movq    %rax,0x28(%rsp)
+.endif
     jmp     wrapper_winclient
 
 graphics.winclientg$p_fc_i_i_i_i_sx$wmframe$wmsize$wmsysbar$:
+.ifdef WINDOWS
+    movq    0x30(%rsp),%rax         # ms: set pointer in stack slot 6
+    movq    (%rax),%rax             # fetch the set value word
+    movq    %rax,0x30(%rsp)
+.endif
     jmp     wrapper_winclientgf
 
 graphics.winclientg$p_i_i_i_i_sx$wmframe$wmsize$wmsysbar$:
+.ifdef WINDOWS
+    movq    0x28(%rsp),%rax         # ms: set pointer in stack slot 5
+    movq    (%rax),%rax             # fetch the set value word
+    movq    %rax,0x28(%rsp)
+.endif
     jmp     wrapper_winclientg
 
 graphics.writejust$p_fc_vc_i:


### PR DESCRIPTION
Found in management_test's window-size-calculate test (frame 31): a (20,10)-character client computed a 30,22 window that delivered only ~(18,8) of client.

## Root cause

The **win64 Pascaline convention passes a set by reference** — the generated call pushes the set constant's address — while the winclient/winclientg C wrappers take the mode set **value** as a plain word (`int ms`). The address was read as the mode bits: wrong style → wrong frame calculation. (Direct probe: `winclientg(600×450, full frame)` returned 600×450 — no frame added; after the fix, 622×506, exactly client + frame.) The SysV convention passes the set value directly, so linux was never affected.

## Fix

Same architecture as the straddling string pairs (#574): **the wrapper reforms**. The four `winclient`/`winclientg` entries dereference the set pointer in its slot under `.ifdef WINDOWS`; SysV assembles to the original plain `jmp`.

Wrappers taking the array-decay `set` type (`setatr`/`resatr`) already receive a pointer and are untouched on windows. (Their linux behavior with value-passed sets is a separate pre-existing question — those tests are commented out on linux.)

Verified: winclientg returns exact adjusted sizes for full-frame and frameless modes; management_test rebuilt for the frame-31 recheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA