### PR TITLE
network wrappers: use 64 bit types for Pascaline parameters (LLP64)

### DIFF
--- a/libs/source/network_wrapper.c
+++ b/libs/source/network_wrapper.c
@@ -1,52 +1,61 @@
-/* Generated network wrappers. Do not edit by hand.
+/* Network wrappers (originally generated, now hand maintained).
  *
  * Compiled against plain glibc stdio (no STDIO_BYPASS): the network
  * library lives in the glibc world. Only the string conversion
  * helpers are shared with the bypass world; they touch no FILE.
+ *
+ * Types: a Pascaline integer is 64 bits on every platform, so the
+ * Pascaline-facing parameters use long long / long long* explicitly
+ * (plain long is only 32 bits on windows). The ami IPv4 address type
+ * is unsigned long -- 64 bits on SysV, 32 bits on windows -- so v4
+ * addresses convert through a local of ami's own type.
  */
 
 #include <network.h>
 
 extern char* cstrz(char* s, int l); /* support.o: trim pad + terminate */
 
-void wrapper_addrnet(char* name, int namel, long* addr)
+void wrapper_addrnet(char* name, int namel, long long* addr)
 {
-    ami_addrnet(cstrz(name, namel), (unsigned long*)addr);
+    unsigned long a; /* ami's v4 address type (64 bits SysV, 32 windows) */
+
+    ami_addrnet(cstrz(name, namel), &a);
+    *addr = a; /* widen to the 64 bit Pascaline integer */
 }
 
-void wrapper_addrnetv6(char* name, int namel, long* addrh, long* addrl)
+void wrapper_addrnetv6(char* name, int namel, long long* addrh, long long* addrl)
 {
     ami_addrnetv6(cstrz(name, namel), (unsigned long long*)addrh, (unsigned long long*)addrl);
 }
 
-int wrapper_maxmsg(long addr)
+int wrapper_maxmsg(long long addr)
 {
-    return ami_maxmsg(addr);
+    return ami_maxmsg((unsigned long)addr);
 }
 
-int wrapper_maxmsgv6(long addrh, long addrl)
+int wrapper_maxmsgv6(long long addrh, long long addrl)
 {
-    return ami_maxmsgv6(addrh, addrl);
+    return ami_maxmsgv6((unsigned long long)addrh, (unsigned long long)addrl);
 }
 
-int wrapper_relymsg(long addr)
+int wrapper_relymsg(long long addr)
 {
-    return ami_relymsg(addr);
+    return ami_relymsg((unsigned long)addr);
 }
 
-int wrapper_relymsgv6(long addrh, long addrl)
+int wrapper_relymsgv6(long long addrh, long long addrl)
 {
-    return ami_relymsgv6(addrh, addrl);
+    return ami_relymsgv6((unsigned long long)addrh, (unsigned long long)addrl);
 }
 
-int wrapper_openmsg(long addr, int port, int secure)
+int wrapper_openmsg(long long addr, int port, int secure)
 {
-    return ami_openmsg(addr, port, secure);
+    return ami_openmsg((unsigned long)addr, port, secure);
 }
 
-int wrapper_openmsgv6(long addrh, long addrl, int port, int secure)
+int wrapper_openmsgv6(long long addrh, long long addrl, int port, int secure)
 {
-    return ami_openmsgv6(addrh, addrl, port, secure);
+    return ami_openmsgv6((unsigned long long)addrh, (unsigned long long)addrl, port, secure);
 }
 
 void wrapper_wrmsg(int fn, char* msg, int msgl)
@@ -71,8 +80,12 @@ int wrapper_waitmsg(int port, int secure)
 
 int wrapper_certmsg(int fn, int which, char* cert, int certl)
 {
-    return ami_certmsg(fn, which, cert, certl);
+    int r;
+
+    r = ami_certmsg(fn, which, cert, certl);
+    /* the out string is space padded back for Pascaline (this ran after
+       the return before, and so never executed) */
     { int _p = 0; while (_p < certl && cert[_p]) _p++;
       while (_p < certl) cert[_p++] = ' '; }
+    return r;
 }
-


### PR DESCRIPTION
Closes the last item on the known LLP64 wrapper list. Audit result across the five bindings:

| binding | status |
|---|---|
| services, graphics, terminal | safe — include `support.h`, whose `#define long long long` remap makes `long` 64-bit on windows |
| sound | safe — uses no `long` at all |
| **network** | **broken** — no support.h (deliberately glibc-world), so `long` = 32 bits on windows |

The damage: the v4 address out-parameter wrote 4 bytes into the 64-bit Pascaline integer (upper half stale), the v6 out-parameters cast `long*` (32-bit pointee) to `unsigned long long*`, and value parameters truncated. Fixed with explicit types: Pascaline-facing params are `long long`/`long long*`; v4 addresses convert through a local of ami's own `unsigned long` (64 on SysV, 32 on windows). SysV build unchanged (identical widths).

Bonus: `wrapper_certmsg`'s certificate pad-fill sat **after its return statement** — dead code, now executed before returning.

Verified: clean win64 compile (0 warnings), network_test links. Runtime validation awaits the network model's windows socket write fix (network_test remains disabled in the regression until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA