### PR TITLE
graphics wrappers: the r9pad slot is SysV only

### DIFF
--- a/libs/source/graphics_wrapper.c
+++ b/libs/source/graphics_wrapper.c
@@ -524,7 +524,12 @@ void wrapper_buffer(int e)
     ami_buffer(stdout, e);
 }
 
-void wrapper_buttonf(pfile pfp, int x1, int y1, int x2, int y2, long r9pad, string s, int sl, int id)
+void wrapper_buttonf(pfile pfp, int x1, int y1, int x2, int y2,
+#ifndef _WIN32
+    long r9pad, /* SysV only: the string pair straddles slot 6, leaving r9 dead;
+                   on win64 the whole pair is stacked and no slot is skipped */
+#endif
+    string s, int sl, int id)
 {
     FILE* f = psystem_libcwrfil(pfp);
     ami_button(f, x1, y1, x2, y2, cstrz(s, sl), id);
@@ -535,7 +540,12 @@ void wrapper_button(int x1, int y1, int x2, int y2, string s, int sl, int id)
     ami_button(stdout, x1, y1, x2, y2, cstrz(s, sl), id);
 }
 
-void wrapper_buttongf(pfile pfp, int x1, int y1, int x2, int y2, long r9pad, string s, int sl, int id)
+void wrapper_buttongf(pfile pfp, int x1, int y1, int x2, int y2,
+#ifndef _WIN32
+    long r9pad, /* SysV only: the string pair straddles slot 6, leaving r9 dead;
+                   on win64 the whole pair is stacked and no slot is skipped */
+#endif
+    string s, int sl, int id)
 {
     FILE* f = psystem_libcwrfil(pfp);
     ami_buttong(f, x1, y1, x2, y2, cstrz(s, sl), id);
@@ -595,7 +605,12 @@ void wrapper_bxor(void)
     ami_bxor(stdout);
 }
 
-void wrapper_checkboxf(pfile pfp, int x1, int y1, int x2, int y2, long r9pad, string s, int sl, int id)
+void wrapper_checkboxf(pfile pfp, int x1, int y1, int x2, int y2,
+#ifndef _WIN32
+    long r9pad, /* SysV only: the string pair straddles slot 6, leaving r9 dead;
+                   on win64 the whole pair is stacked and no slot is skipped */
+#endif
+    string s, int sl, int id)
 {
     FILE* f = psystem_libcwrfil(pfp);
     ami_checkbox(f, x1, y1, x2, y2, cstrz(s, sl), id);
@@ -606,7 +621,12 @@ void wrapper_checkbox(int x1, int y1, int x2, int y2, string s, int sl, int id)
     ami_checkbox(stdout, x1, y1, x2, y2, cstrz(s, sl), id);
 }
 
-void wrapper_checkboxgf(pfile pfp, int x1, int y1, int x2, int y2, long r9pad, string s, int sl, int id)
+void wrapper_checkboxgf(pfile pfp, int x1, int y1, int x2, int y2,
+#ifndef _WIN32
+    long r9pad, /* SysV only: the string pair straddles slot 6, leaving r9 dead;
+                   on win64 the whole pair is stacked and no slot is skipped */
+#endif
+    string s, int sl, int id)
 {
     FILE* f = psystem_libcwrfil(pfp);
     ami_checkboxg(f, x1, y1, x2, y2, cstrz(s, sl), id);
@@ -1164,7 +1184,12 @@ void wrapper_getwidgettext(int id, string s, int sl)
     { int _p = 0; while (_p < sl && s[_p]) _p++; while (_p < sl) s[_p++] = ' '; }
 }
 
-void wrapper_groupf(pfile pfp, int x1, int y1, int x2, int y2, long r9pad, string s, int sl, int id)
+void wrapper_groupf(pfile pfp, int x1, int y1, int x2, int y2,
+#ifndef _WIN32
+    long r9pad, /* SysV only: the string pair straddles slot 6, leaving r9 dead;
+                   on win64 the whole pair is stacked and no slot is skipped */
+#endif
+    string s, int sl, int id)
 {
     FILE* f = psystem_libcwrfil(pfp);
     ami_group(f, x1, y1, x2, y2, cstrz(s, sl), id);
@@ -1175,7 +1200,12 @@ void wrapper_group(int x1, int y1, int x2, int y2, string s, int sl, int id)
     ami_group(stdout, x1, y1, x2, y2, cstrz(s, sl), id);
 }
 
-void wrapper_groupgf(pfile pfp, int x1, int y1, int x2, int y2, long r9pad, string s, int sl, int id)
+void wrapper_groupgf(pfile pfp, int x1, int y1, int x2, int y2,
+#ifndef _WIN32
+    long r9pad, /* SysV only: the string pair straddles slot 6, leaving r9 dead;
+                   on win64 the whole pair is stacked and no slot is skipped */
+#endif
+    string s, int sl, int id)
 {
     FILE* f = psystem_libcwrfil(pfp);
     ami_groupg(f, x1, y1, x2, y2, cstrz(s, sl), id);
@@ -1592,7 +1622,12 @@ void wrapper_querysave(string s, int sl)
     { int _p = 0; while (_p < sl && s[_p]) _p++; while (_p < sl) s[_p++] = ' '; }
 }
 
-void wrapper_radiobuttonf(pfile pfp, int x1, int y1, int x2, int y2, long r9pad, string s, int sl, int id)
+void wrapper_radiobuttonf(pfile pfp, int x1, int y1, int x2, int y2,
+#ifndef _WIN32
+    long r9pad, /* SysV only: the string pair straddles slot 6, leaving r9 dead;
+                   on win64 the whole pair is stacked and no slot is skipped */
+#endif
+    string s, int sl, int id)
 {
     FILE* f = psystem_libcwrfil(pfp);
     ami_radiobutton(f, x1, y1, x2, y2, cstrz(s, sl), id);
@@ -1603,7 +1638,12 @@ void wrapper_radiobutton(int x1, int y1, int x2, int y2, string s, int sl, int i
     ami_radiobutton(stdout, x1, y1, x2, y2, cstrz(s, sl), id);
 }
 
-void wrapper_radiobuttongf(pfile pfp, int x1, int y1, int x2, int y2, long r9pad, string s, int sl, int id)
+void wrapper_radiobuttongf(pfile pfp, int x1, int y1, int x2, int y2,
+#ifndef _WIN32
+    long r9pad, /* SysV only: the string pair straddles slot 6, leaving r9 dead;
+                   on win64 the whole pair is stacked and no slot is skipped */
+#endif
+    string s, int sl, int id)
 {
     FILE* f = psystem_libcwrfil(pfp);
     ami_radiobuttong(f, x1, y1, x2, y2, cstrz(s, sl), id);


### PR DESCRIPTION
widget_test died at frame 2 (first widget creation) on windows. The eight file-form widget wrappers carry an explicit r9pad parameter — a SysV accommodation for the string pair straddling slot 6 (dead r9). On win64 there is no straddle, so the pad shifted every following parameter by one (backtrace: s=12 the length, sl=1 the id, id=garbage → crash). The pad is now #ifndef _WIN32. Verified with a minimal repro (crash before, clean after); widget_test rebuilt and installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA