### PR TITLE
web: caption the smiley: Happy Pascal

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,8 @@
 body { font-family: "Lucida Grande", Geneva, Helvetica, Arial, sans-serif; font-size: 14px; margin: 0; padding: 0; background: #fff; color: #333; line-height: 1.6; }
 .page-header { background: linear-gradient(to bottom, #D5DDEC 0%, #CAD4E8 50%, #B2C0DD 100%); border-bottom: 1px solid #A3B4D7; padding: 20px 40px; display: flex; align-items: center; justify-content: space-between; }
 .header-text { flex: 1; }
-.header-logo { flex-shrink: 0; margin-left: 20px; }
+.header-logo { flex-shrink: 0; margin-left: 20px; text-align: center; }
+.logo-caption { font-size: 12px; font-style: italic; color: #364D7C; margin-top: 2px; }
 .page-title { font-size: 280%; color: #1C2941; font-weight: bold; margin: 0; }
 .page-subtitle { font-size: 15px; color: #364D7C; margin-top: 4px; }
 .content { max-width: 900px; margin: 0 auto; padding: 30px 40px; }
@@ -39,7 +40,10 @@ pre { background: #F5F7FA; border: 1px solid #C4CFE5; border-radius: 4px; paddin
 <div class="page-title">Pascal-P6</div>
 <div class="page-subtitle">A public domain Pascaline compiler and development system</div>
 </div>
-<div class="header-logo"><img src="doc/pascal_smile.bmp" alt="Pascal"></div>
+<div class="header-logo">
+<img src="doc/pascal_smile.bmp" alt="Happy Pascal">
+<div class="logo-caption">Happy Pascal</div>
+</div>
 </div>
 <div class="content">
 


### PR DESCRIPTION
Adds the caption Happy Pascal under the Blaise Pascal smiley in the page header, in small italics matching the header palette -- the companion to Francois on the amitk page. Alt text updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA