### PR TITLE
Makefile: snapshot parser and passym into the hosts tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1140,8 +1140,8 @@ bin/spew: $(SOURCE)/spew.c
 # restorable set. The configure script performs the reverse restore. Run
 # after a clean regression, before committing.
 #
-HOSTBINS=cmach cmacht cmachg genobj pc pcom pgen pgen_arm64 pint pintt \
-	pintg pmach pmacht pmachg spew
+HOSTBINS=cmach cmacht cmachg genobj parser passym pc pcom pgen pgen_arm64 \
+	pint pintt pintg pmach pmacht pmachg spew
 HOSTLIBS=main.o parse.o psystem.a services.a strings.o terminal.a graphics.a \
 	sound.a network.a gnome_widgets.o
 


### PR DESCRIPTION
Makefile: snapshot parser and passym into the hosts tree

A fresh clone gets its bin executables from the hosts tree via
configure, and the hostinstall snapshot list did not include parser and
passym -- so no clone could ever receive the tools the vscode Pascaline
extension's language server needs, and diagnostics/symbols silently
never work on a new checkout. Added both to HOSTBINS; they enter the
snapshot on the next hostinstall after a build (bin/build now compiles
them since the vscode batch).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA
