### PR TITLE
vscode: put pc's directory on PATH when spawning it

### DIFF
--- a/vscode-pascaline/src/extension.ts
+++ b/vscode-pascaline/src/extension.ts
@@ -60,8 +60,17 @@ class PascalineTaskProvider implements vscode.TaskProvider {
         const base = path.basename(file, path.extname(file));
         const def = definition ??
             { type: 'pascaline', task: 'build', file: file };
-        const exec = new vscode.ProcessExecution(findTool('pc'), [base],
-                                                 { cwd: dir });
+        const pc = findTool('pc');
+        // pc finds its subtools (pcom, pgen) on PATH, so put its own
+        // directory there -- otherwise a workspace whose bin is not on the
+        // editor's PATH fails the compile with no message.
+        const env: { [key: string]: string } = {};
+        if (path.isAbsolute(pc)) {
+            env['PATH'] = path.dirname(pc) + path.delimiter +
+                (process.env.PATH ?? '');
+        }
+        const exec = new vscode.ProcessExecution(pc, [base],
+                                                 { cwd: dir, env: env });
         const task = new vscode.Task(def, vscode.TaskScope.Workspace,
                                      'build ' + base, 'pascaline', exec, []);
         task.group = vscode.TaskGroup.Build;

--- a/vscode-pascaline/src/pascalineDebug.ts
+++ b/vscode-pascaline/src/pascalineDebug.ts
@@ -228,7 +228,14 @@ export class PascalineDebugSession extends LoggingDebugSession {
      */
     private compile(pcPath: string, programName: string, cwd: string): Promise<void> {
         return new Promise((resolve, reject) => {
-            execFile(pcPath, [programName, '-pint'], { cwd }, (error, stdout, stderr) => {
+            // pc finds its subtools (pcom, pgen) on PATH, so make sure its
+            // own directory is there when we have a real path to it.
+            const env = { ...process.env };
+            if (path.isAbsolute(pcPath)) {
+                env['PATH'] = path.dirname(pcPath) + path.delimiter +
+                    (env['PATH'] ?? '');
+            }
+            execFile(pcPath, [programName, '-pint'], { cwd, env }, (error, stdout, stderr) => {
                 if (stdout) {
                     this.sendEvent(new OutputEvent(stdout, 'console'));
                 }


### PR DESCRIPTION
vscode: put pc's directory on PATH when spawning it

pc resolves its subtools (pcom, pgen) through PATH, not relative to its
own location. On a fresh clone where bin is not on the editor's PATH,
the extension found pc by walking up to the workspace bin and ran it --
and pc then failed to spawn pcom and exited 1 with no output at all.
The task provider and the debug adapter's compile step now prepend the
resolved pc's own directory to PATH for the child process.

Found testing the fresh-clone flow in pascal-p6_test: configure.bat
populates bin, but nothing puts it on PATH, and every compile through
the extension died silently.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA
