### PR TITLE
terminal_test: survive terminate before the benchmarks run

### DIFF
--- a/libs/tests/terminal_test.pas
+++ b/libs/tests/terminal_test.pas
@@ -356,6 +356,14 @@ end;
 
 begin
 
+   { clear the benchmark table: a terminate can reach the report before
+     any benchmark has run }
+   for bi := bncharw to bnbuffer do begin
+
+      benchtab[bi].iter := 0;
+      benchtab[bi].time := 0
+
+   end;
    select(output, 2, 2); { move off the display buffer }
    { set black on white text }
    fcolor(output, black);
@@ -1181,7 +1189,10 @@ begin
 
       end;
       write(benchtab[bi].time*0.0001:6:2, '    ');
-      writeln(benchtab[bi].time*0.0001/benchtab[bi].iter:1:8)
+      if benchtab[bi].iter > 0 then
+         writeln(benchtab[bi].time*0.0001/benchtab[bi].iter:1:8)
+      else
+         writeln('      --') { benchmark did not run }
 
    end;
    writeln


### PR DESCRIPTION
terminal_test: survive terminate before the benchmarks run

Ctrl-c jumps to the terminate label, which prints the benchmark table
-- and the per-figure column divides by each benchmark's iteration
count, zero for any benchmark that never ran ("Runtime error:
terminal_test:...:Zero divide" on every early exit, all platforms).

Clear the benchmark table at program start and print "--" for the per
figure of a benchmark with no iterations.

Verified: ctrl-c out of the first frame now ends with "Test complete"
and a table of zeros and dashes, no error.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA
