### PR TITLE
network: register the write side dup with the windows model, re-enable network_test

### DIFF
--- a/bin/regress
+++ b/bin/regress
@@ -188,16 +188,11 @@ function do_regress {
     testlibprog $option strings_test
     dotestresult libs/tests libs/tests strings_test
 
-    # network_test is disabled for now: the windows network model's write
-    # side is not socket-backed (the dup'd write descriptor writes to the nul
-    # device instead of the socket), so the client/server exchange deadlocks
-    # and, with no watchdog in the harness, wedges the whole run indefinitely.
-    # Re-enable once the network port's socket-file close/write path is fixed.
-    #echo "Testing network_test..."
-    #echo "network_test run" >> "$report"
-    #setout libs/tests
-    #testlibprog $option network_test
-    #dotestresult libs/tests libs/tests network_test
+    echo "Testing network_test..."
+    echo "network_test run" >> "$report"
+    setout libs/tests
+    testlibprog $option network_test
+    dotestresult libs/tests libs/tests network_test
 
     echo "Testing services_test..."
     echo "services_test run" >> "$report"

--- a/libs/source/network_support.c
+++ b/libs/source/network_support.c
@@ -77,6 +77,16 @@ static void bindnet(pfile infile, pfile outfile, FILE* gf)
     psystem_libcatcfil(infile, af, 0);
     fd2 = dup(fd);
     if (fd2 >= 0 && fd2 < MAXNETFIL) netfil[fd2] = gf; /* both find the conn */
+#ifdef __MINGW32__
+    /* The windows network model tracks connections by descriptor (the
+       descriptor itself is parked on the nul device; a winsock SOCKET is
+       not a CRT descriptor as on linux). Enter the duplicate in the model,
+       or the write side's I/O would go to the nul device. */
+    {
+        extern void ami_netshare(int fd, int fd2);
+        ami_netshare(fd, fd2);
+    }
+#endif
     af = stdio_fdopen(fd2, "r+");
     psystem_libcatcfil(outfile, af, 1);
 }


### PR DESCRIPTION
network: register the write side dup with the windows model, re-enable
network_test

The windows network model tracks connections by descriptor, and the
write side of a pair is a dup the model never saw -- its writes went to
the parked nul device, deadlocking the exchange (the reason
network_test was disabled in the regression). bindnet now enters the
duplicate via the model's new ami_netshare (amitk#152).

Re-enable network_test in the regression: on windows it now passes 7/7
matching the golden file, including the previously deadlocking TCP
clear exchange and the DTLS secured message exchange. This also runtime
validates the LLP64 wrapper rework from #579.

Requires amitk#152.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA
