### PR TITLE
network: present a socket as a bonded file pair in psystem

### DIFF
--- a/bin/regress
+++ b/bin/regress
@@ -188,16 +188,11 @@ function do_regress {
     testlibprog $option strings_test
     dotestresult libs/tests libs/tests strings_test
 
-    # network_test is disabled for now: the windows network model's write
-    # side is not socket-backed (the dup'd write descriptor writes to the nul
-    # device instead of the socket), so the client/server exchange deadlocks
-    # and, with no watchdog in the harness, wedges the whole run indefinitely.
-    # Re-enable once the network port's socket-file close/write path is fixed.
-    #echo "Testing network_test..."
-    #echo "network_test run" >> "$report"
-    #setout libs/tests
-    #testlibprog $option network_test
-    #dotestresult libs/tests libs/tests network_test
+    echo "Testing network_test..."
+    echo "network_test run" >> "$report"
+    setout libs/tests
+    testlibprog $option network_test
+    dotestresult libs/tests libs/tests network_test
 
     echo "Testing services_test..."
     echo "services_test run" >> "$report"

--- a/libs/source/network_support.c
+++ b/libs/source/network_support.c
@@ -37,6 +37,7 @@ extern void* cstr2pstr(char* cs, int l);
 
 /* psystem runtime (Ami-stdio world) */
 extern void  psystem_libcatcfil(pfile f, void* fp, long wr);
+extern void  psystem_libcatcfilset(pfile infile, pfile outfile, void* fp);
 extern void* psystem_libcrdfil(pfile f);
 extern void* psystem_libcwrfil(pfile f);
 
@@ -62,23 +63,22 @@ static FILE* netfil[MAXNETFIL];
 static void bindnet(pfile infile, pfile outfile, FILE* gf)
 {
     int   fd;
-    int   fd2;
     void* af;
 
     fd = fileno(gf); /* glibc descriptor of the connection */
     if (fd >= 0 && fd < MAXNETFIL) netfil[fd] = gf; /* save for cert calls */
-    /* Reopen the descriptor in the Ami-stdio world, one file per side. The
-       Ami stdio tracks one FILE per descriptor, so the write side gets a
-       duplicate of the descriptor (which also gives each side independent
-       close semantics). Both sides open in update mode: the socket
-       descriptor is read-write, and the Ami fdopen verifies the requested
-       mode against the descriptor's actual access mode. */
+    /* A socket is one bidirectional channel; Pascal wants unidirectional
+       text files, so it is presented as a bonded pair -- a read file and a
+       write file over the ONE stream (one descriptor). Closing either closes
+       the connection once; the pairing and single close live in psystem
+       (psystem_libcatcfilset / psystem_bondfil). No dup, and so no per-host
+       descriptor-to-socket bookkeeping. Open in update mode: the socket is
+       read-write and the Ami fdopen checks the mode against the descriptor.
+       Line buffer the stream so a writeln reaches the socket at its newline
+       without a close to flush it, while reads stay buffered. */
     af = stdio_fdopen(fd, "r+");
-    psystem_libcatcfil(infile, af, 0);
-    fd2 = dup(fd);
-    if (fd2 >= 0 && fd2 < MAXNETFIL) netfil[fd2] = gf; /* both find the conn */
-    af = stdio_fdopen(fd2, "r+");
-    psystem_libcatcfil(outfile, af, 1);
+    setvbuf((FILE*)af, NULL, _IOLBF, BUFSIZ);
+    psystem_libcatcfilset(infile, outfile, af);
 }
 
 /* recover the connection's glibc FILE from a Pascaline file */

--- a/libs/tests/network_test.pas
+++ b/libs/tests/network_test.pas
@@ -274,10 +274,9 @@ begin
 
    waitnet(fi, fo, port, secure);
    getline(fi, buff, len); { client line received }
-   writeln(fo, 'Hello, client');
-   close(fo); { flush the reply to the client }
+   writeln(fo, 'Hello, client'); { line buffered: sent at the newline }
    { hold the connection up briefly so the client can read and the
-     certificate tests can inspect, then exit (closing it) }
+     certificate tests can inspect, then close (either side ends it) }
    pause(2*second);
    close(fi)
 
@@ -336,11 +335,10 @@ begin
    spawn('tcpserver', port, secure);
    addrnet('localhost', addr);
    opennet(fi, fo, addr, port, secure);
-   writeln(fo, 'Hello, server');
-   close(fo); { flush; the read side keeps the connection up }
-   getline(fi, buff, len);
+   writeln(fo, 'Hello, server'); { line buffered: sent at the newline }
+   getline(fi, buff, len); { read the reply, connection still open }
    pass := lineis(buff, len, 'Hello, client');
-   close(fi);
+   close(fi); { close once; either side ends the bonded connection }
    report(name, pass)
 
 end;
@@ -409,10 +407,9 @@ begin
    report('certnet raw certificate', not blank(cert));
 
    { complete the exchange so the server exits }
-   writeln(fo, 'Hello, server');
-   close(fo);
-   getline(fi, buff, len); { response }
-   close(fi)
+   writeln(fo, 'Hello, server'); { line buffered: sent at the newline }
+   getline(fi, buff, len); { response, connection still open }
+   close(fi) { close once; either side ends the bonded connection }
 
 end;
 

--- a/source/cmach/cmach.c
+++ b/source/cmach/cmach.c
@@ -730,6 +730,7 @@ FILE* filtable[MAXFIL+1]; /* general file holders */
 filnam filnamtab[MAXFIL+1]; /* assigned name of files */
 boolean filanamtab[MAXFIL+1]; /* name has been assigned flags */
 filsts filstate[MAXFIL+1]; /* file state holding */
+int filbond[MAXFIL+1]; /* bonded partner logical file no. (0 none) */
 boolean filbuff[MAXFIL+1]; /* file buffer full status */
 boolean fileoln[MAXFIL+1]; /* last file character read was eoln */
 boolean filecr[MAXFIL+1];  /* last file character read was cr */
@@ -1321,6 +1322,35 @@ void psystem_libcatcfil(unsigned char* f, FILE* fp, long wr)
     if (filstate[fn] == fsread || filstate[fn] == fswrite) fclose(filtable[fn]);
     filtable[fn] = fp;   /* attach the libc file */
     filstate[fn] = wr ? fswrite : fsread;
+}
+
+/* Bond two Pascal files as a pair: two logical files sharing one stream.
+   Closing either closes the shared stream once and marks both closed, so
+   any later use or close of either side is an error. This presents a
+   bidirectional connection (a socket) to Pascal -- which wants
+   unidirectional text files -- as a read file and a write file without
+   duplicating the underlying descriptor. */
+void psystem_bondfil(unsigned char* a, unsigned char* b)
+{
+    address ada = (address)(a-store);
+    address adb = (address)(b-store);
+    int fna, fnb;
+
+    valfil(ada); valfil(adb);
+    fna = store[ada]; fnb = store[adb];
+    if (fna <= COMMANDFN || fnb <= COMMANDFN) errore(FILEMODEINCORRECT);
+    filbond[fna] = fnb; /* bond each to the other */
+    filbond[fnb] = fna;
+}
+
+/* Attach one libc stream to a bonded pair as a set: bind both Pascal files
+   to the one stream and bond them, in one operation. */
+void psystem_libcatcfilset(unsigned char* infile, unsigned char* outfile,
+                           FILE* fp)
+{
+    psystem_libcatcfil(infile, fp, 0);  /* bind read side */
+    psystem_libcatcfil(outfile, fp, 1); /* bind write side */
+    psystem_bondfil(infile, outfile);   /* bond the pair */
 }
 
 /* the write-side counterpart of psystem_libcrdfil: the graphics support layer
@@ -2822,6 +2852,17 @@ void callsp(void)
                 if (!filanamtab[fn]) remove(filnamtab[fn]);
                 filanamtab[fn] = FALSE; /* break any name association */
                 filstate[fn] = fsclosed;
+                /* A bonded pair shares one stream: closing either closes it
+                   once (just done) and ends both. The partner references the
+                   same, now closed, stream, so mark it closed without closing
+                   again; any later use or close of the partner is an error. */
+                if (filbond[fn]) {
+                    j = filbond[fn];
+                    filbond[fn] = 0; /* dissolve the bond both ways */
+                    filbond[j] = 0;
+                    filanamtab[j] = FALSE;
+                    filstate[j] = fsclosed;
+                }
                 break;
     case 48 /*pos*/: popint(i); popadr(ad); valfil(ad); fn = store[ad];
                 if (i < 1) errore(INVALIDFILEPOSITION);
@@ -3730,6 +3771,7 @@ int main (int argc, char *argv[])
     for (i = 1; i <= MAXFIL; i++) {
         filstate[i] = fsnone; /* never opened */
         filanamtab[i] = FALSE; /* no name assigned */
+        filbond[i] = 0; /* not bonded to a partner */
     }
 
     /* construct bit equivalence table */

--- a/source/pgen/psystem.c
+++ b/source/pgen/psystem.c
@@ -525,6 +525,7 @@ static boolean fileoln[MAXFIL+1]; /* last file character read was eoln */
 static boolean filecr[MAXFIL+1];  /* last file character read was cr */
 static boolean filelf[MAXFIL+1];  /* last file character read was lf */
 static boolean filbof[MAXFIL+1]; /* beginning of file */
+static int     filbond[MAXFIL+1]; /* bonded partner logical file no. (0 none) */
 static varptr varlst; /* active var block pushdown stack */
 static varptr varfre; /* free var block entries */
 static wthptr wthlst; /* active with block pushdown stack */
@@ -4927,19 +4928,32 @@ void psystem_clst(
 
 {
 
-    int fn;
+    int fn, pn;
 
     valfil(f); /* validate file */
     fn = *f; /* get logical file no. */
 
     /* check file is open */
-    if (filstate[fn] != fsread && filstate[fn] != fswrite) 
+    if (filstate[fn] != fsread && filstate[fn] != fswrite)
         errore(modnam, __LINE__, FILENOTOPEN);
     if (fclose(filtable[fn])) errore(modnam, __LINE__, FILECLOSEFAIL);
     /* if the file is temp, remove now */
     if (!filanamtab[fn]) remove(filnamtab[fn]);
     filanamtab[fn] = FALSE; /* break any name association */
     filstate[fn] = fsclosed; /* set status closed */
+    /* A bonded pair shares one stream: closing either closes it once (just
+       done) and ends both. The partner references the same, now closed,
+       stream, so do not close it again; mark it closed so any later use or
+       close of the partner is a "file not open" error. */
+    pn = filbond[fn];
+    if (pn) {
+
+        filbond[fn] = 0; /* dissolve the bond both ways */
+        filbond[pn] = 0;
+        filanamtab[pn] = FALSE;
+        filstate[pn] = fsclosed;
+
+    }
 
 }
 
@@ -4957,19 +4971,29 @@ void psystem_clsb(
 
 {
 
-    int fn;
+    int fn, pn;
 
     valfil(f); /* validate file */
     fn = *f; /* get logical file no. */
 
     /* check file is open */
-    if (filstate[fn] != fsread && filstate[fn] != fswrite) 
+    if (filstate[fn] != fsread && filstate[fn] != fswrite)
         errore(modnam, __LINE__, FILENOTOPEN);
     if (fclose(filtable[fn])) errore(modnam, __LINE__, FILECLOSEFAIL);
     /* if the file is temp, remove now */
     if (!filanamtab[fn]) remove(filnamtab[fn]);
     filanamtab[fn] = FALSE; /* break any name association */
     filstate[fn] = fsclosed; /* set status closed */
+    /* bonded pair: close ends both sides, once (see psystem_clst) */
+    pn = filbond[fn];
+    if (pn) {
+
+        filbond[fn] = 0; /* dissolve the bond both ways */
+        filbond[pn] = 0;
+        filanamtab[pn] = FALSE;
+        filstate[pn] = fsclosed;
+
+    }
 
 }
 
@@ -5718,6 +5742,63 @@ void psystem_libcatcfil(
 
 /** ****************************************************************************
 
+Bond two Pascal files as a pair
+
+Marks two Pascal files as a bonded pair: two logical files sharing one
+underlying stream. Closing either closes the shared stream once and marks
+both files closed, so any later use or close of either side is an error.
+This is how a bidirectional connection (a socket) is presented to Pascal --
+which insists on unidirectional text files -- as a read file and a write
+file without duplicating the underlying descriptor.
+
+*******************************************************************************/
+
+void psystem_bondfil(
+    /** first file of the pair */  pasfil* a,
+    /** second file of the pair */ pasfil* b
+)
+
+{
+
+    int fna, fnb;
+
+    valfil(a); valfil(b); /* validate both files */
+    fna = *a; fnb = *b; /* get logical file numbers */
+    if (fna <= COMMANDFN || fnb <= COMMANDFN)
+        errore(modnam, __LINE__, FILEMODEINCORRECT);
+    filbond[fna] = fnb; /* bond each to the other */
+    filbond[fnb] = fna;
+
+}
+
+/** ****************************************************************************
+
+Attach one libc stream to a bonded Pascal file pair
+
+Binds both Pascal files of a pair to a single libc stream and bonds them, as
+one operation. The read file gets the read binding, the write file the write
+binding; both reference the one stream, so the connection uses a single
+descriptor. Doing it as a set keeps the pair consistent for tasks that may
+hold the two sides independently.
+
+*******************************************************************************/
+
+void psystem_libcatcfilset(
+    /** read side Pascal file */  pasfil* infile,
+    /** write side Pascal file */ pasfil* outfile,
+    /** libc stream to attach */  void*   fp
+)
+
+{
+
+    psystem_libcatcfil(infile, fp, 0);  /* bind read side */
+    psystem_libcatcfil(outfile, fp, 1); /* bind write side */
+    psystem_bondfil(infile, outfile);   /* bond the pair */
+
+}
+
+/** ****************************************************************************
+
 Compare strings
 
 Compares two strings, and returns:
@@ -6353,6 +6434,7 @@ static void init(int argc, char* argv[])
         filstate[i] = fsnone; /* never opened */
         filanamtab[i] = FALSE; /* no name assigned */
         filtable[i] = NULL; /* clear Unix file pointer */
+        filbond[i] = 0; /* not bonded to a partner */
 
     }
 


### PR DESCRIPTION
## What

Presents a network connection to Pascal as a **bonded file pair** owned by psystem, deleting the descriptor-duplication and per-host socket bookkeeping that the previous approach needed.

## Why

A socket is one bidirectional channel; Pascal wants unidirectional text files, so `opennet` returns a read file and a write file. The old binding `dup`'d the descriptor to make the two sides independently closable -- which on windows forced the network model to track the socket across both descriptors (`ami_netshare`) and refcount the close, reconstructing by hand what the kernel gives linux `dup` for free.

The pairing is really a Pascal-file-layer concern (it exists only because Pascal splits a bidirectional channel into two files), so it belongs in psystem, not pushed down into every host's socket model.

## Changes

- **psystem** (`source/pgen/psystem.c`): `filbond[]` in the file tracking arrays; `psystem_bondfil()` and the atomic `psystem_libcatcfilset()` ("open as a set", handy for tasks holding the two sides independently). Closing either side `fclose`s the one shared stream and marks both `fsclosed`; using or closing the partner is then a "file not open" error. Non-bonded files are untouched (`filbond` stays 0), so ordinary file I/O is unaffected.
- **`network_support.c`** `bindnet`: `fdopen` once, line-buffered, `psystem_libcatcfilset(infile, outfile, af)`. **No dup, no netshare.**
- **`network_test`**: write / read / close-one discipline.
- **`bin/regress`**: network_test re-enabled.

## Result

network_test passes **7/7 on windows, matching the golden file**; `hello` and normal file I/O unaffected.

## Notes

- Requires **amitk PR #153** (getpgm true-path fix). Submodule bump follows once that merges.
- **Supersedes** #588 and amitk #152 (the `ami_netshare` approach), which are closed.
- User-visible semantics: a network program closes **one** side of the pair; closing or using the other is an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQRpvi49ywSPC8c2KMDEA
