### PR TITLE
arm64 pgen: add vin and cps code generation handlers (WIP)

### DIFF
--- a/source/pgen/arm64/pgen.pas
+++ b/source/pgen/arm64/pgen.pas
@@ -2289,6 +2289,44 @@ override procedure assemble; (*translate symbolic code into machine code and sto
     end
   end;
 
+  { Vector initialize dynamic (vin). Allocates a dynamic container and fills
+    its template. q is the number of index levels, q1 the base element size.
+    The template/pointer address is on top of the stack, with the q dimensions
+    below it. psystem_vin reads the dimensions as a contiguous long array, so
+    they are packed 8 bytes apart into a 16 byte aligned block (as callnwldsl
+    does for its tag list; pshexps lays entries 16 apart, which will not do).
+    The first dimension popped (nearest the template) goes to the highest slot,
+    matching the push order the AMD64 backend produces: al[0] is the last
+    dimension popped. }
+  procedure callvin;
+  var frereg: regset; ep, ep2: expptr; i, alloc: integer; stkadrs: integer;
+  begin
+    stkadrs := stkadr;
+    frereg := allreg; popstk(ep); { template/pointer address }
+    alloc := ((q*intsize+15) div 16)*16;
+    if alloc > 0 then begin
+      wrtins(' sub sp, sp, #^0 // reserve dimension list', alloc);
+      stkadr := stkadr-alloc
+    end;
+    for i := 1 to q do begin
+      frereg := allreg; popstk(ep2); assreg(ep2, frereg, rgnull, rgnull);
+      dmptre(ep2); genexp(ep2);
+      wrtins(' str %1, [sp, #^0] // place dimension', (q-i)*intsize, ep2^.r1);
+      deltre(ep2)
+    end;
+    assreg(ep, allreg, rgx2, rgnull); dmptre(ep); genexp(ep); { template -> x2 }
+    wrtins(' mov x0, #^0 // number of levels', q);
+    wrtins(' mov x1, #^0 // base element size', q1);
+    wrtins(' mov x3, sp // dimension list');
+    wrtins(' bl psystem_vin // fill template and allocate variable');
+    if alloc > 0 then begin
+      wrtins(' add sp, sp, #^0 // dump dimensions from stack', alloc);
+      stkadr := stkadr+alloc
+    end;
+    deltre(ep);
+    stkadr := stkadrs
+  end;
+
 begin { assemble }
   refer(dmplst); { diagnostics }
   refer(dmptmp);
@@ -2333,6 +2371,21 @@ begin { assemble }
     {lto}
     234: begin labelsearch(def, val, sp, blk);
       getexp(ep); ep^.qs := sp; ep^.fl := sp; attach(ep); pshstk(ep)
+    end;
+
+    {vin}
+    226: begin parqq;
+      writeln(prr, '// generating: ', op:3, ': ', instab[op].instr);
+      callvin;
+      botstk
+    end;
+
+    {cps}
+    176: begin
+      getexp(ep); popstk(ep2); popstk(ep3);
+      duptre(ep2, ep^.r); duptre(ep3, ep^.l); pshstk(ep3); pshstk(ep2);
+      frereg := allreg; assreg(ep, frereg, rgnull, rgnull);
+      dmptre(ep); genexp(ep); deltre(ep)
     end;
 
     {ixa}


### PR DESCRIPTION
## Status: draft / WIP — closes the generation crash, runtime correctness bug remains

## Problem

The arm64 code generator crashed with `*** Runtime error: Master exception` while generating **any** module that uses dynamic containers or template comparison — `strings` and `parse` in particular. Two opcode handlers present in the amd64 backend were missing from arm64:

- **`vin`** (vector initialize dynamic, opcode 226) — allocates a dynamic container and fills its template. The first opcode `strings.pas` hits (`new(p, s)`).
- **`cps`** (compare simple templates, opcode 176) — arm64 had the register-allocation passes but not the **code-generation** arm in the main dispatch.

`hello`/`iso7185pat` never exercise these, which is why the base set worked while `strings` did not.

## Change (`source/pgen/arm64/pgen.pas`)

- Added the **`callvin`** helper + the `vin` (226) case arm. Dimensions are packed 8 bytes apart into a 16-byte-aligned block, since `psystem_vin` reads them as a contiguous long array (arm64's `pshexps` lays entries 16 apart and can't be used — this mirrors the existing `callnwldsl`).
- Added the **`cps`** (176) code-gen arm, verbatim from the amd64 backend (arch-neutral tree manipulation).

## Result

- `pgen_arm64` now **fully generates** `strings.s` — 5,040 lines (crash) → 139,730 lines (complete). **The generation crash is closed.**
- **No regression**: `hello`/`roman`/`prime`/`qsort` and the **`iso7185pat` conformance test** still build and run correctly under `qemu-aarch64` (iso7185pat: full golden match).

## Known issue (why this is a draft)

The generated code is **not yet runtime-correct**. `strings_test` builds and links but faults under qemu (**SIGILL** — a branch into container-template data), so the `vin`/`cps` template path still has a code-generation correctness bug. This commit closes the generation crash and isolates the remaining work to codegen correctness.

The rebuilt `pgen_arm64` binary is **deliberately not included** — committing a product with a known runtime bug would give arm64 builds broken `strings`. Products land once the runtime bug is fixed.

## Root cause of the SIGILL (fully traced — for the follow-up fix)

The SIGILL is **not** in the `vin`/`cps` opcode code itself. It is a pre-existing arm64 **module-init-strip / template layout** bug that only became reachable once generation stopped crashing (`strings` never got past `vin` before).

**Mechanism:**

- `strings.5` is the module's template/globals-init strip, called via `cal strings.5` (`bl strings.5`). Its body is template-definition directives (`g 128` globals, `e`/`f` element/field) that emit **template data**, immediately followed by the constants-skip `b 1f` (arm64 `jmpfwd`) and the resume `1:` (after `codealign` → `.balign 4`).
- The module-init design relies on **falling through**: after the strip skips its inline constants, the resume `1:` is expected to land on the next executable code that chains the init sequence.
- The generated `.s` is structurally identical on both arches (one `1:`, correct target). The divergence is at **link/layout time**:
  - **amd64**: `strings.5: jmpq <strings_test>` — the resume `1:` coincides with real code → fall-through works.
  - **arm64**: `strings.5: b <template205+8>` — the resume `1:` sits at the end of `strings.o`'s `.text`, immediately followed by the next linked object's **template data** (`0, 8, 0x11, 0x328 …`). Executing that data faults (SIGILL).

**Evidence:** disassembly of the linked `strings_test` shows `strings.5` → `b 0x4295ac`, and `0x4295ac` = `strings.205+8` = `.word 0x00000000` followed by template words — data, not code. The native amd64 build has `strings.5` → `jmpq <strings_test>` (code).

## Follow-up fix (deliberate — do not patch blind)

The arm64 module-init strip must not rely on link-order fall-through to reach its continuation. Candidate directions:

- End the init strip with an explicit `ret` (or explicit branch to the init continuation) rather than falling through past the constants, or
- Move the module template/globals data out of the init strip's fall-through path (a separate data section), so the resume `1:` lands on code.

This touches the module-init contract that **amd64 also depends on** and the shared `independent.pas` `xlate`/`gencst` emission, so a wrong change corrupts the constants section of **every** module. It needs validation across all modules (native regression + qemu), not just `strings`.

## Status of the bootstrap set on arm64/qemu

- `iso7185pat` (base functional conformance), `hello`/`roman`/`prime`/`qsort`, and `services` — **pass** under qemu (unaffected by this change).
- `strings`/`parse` — **generation now works** (this PR); runtime blocked on the module-init-strip layout bug above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
