### PR TITLE
Raise pcom maxtrk / pint maxsym for large type digests (fixes #592)

### DIFF
--- a/source/pcom.pas
+++ b/source/pcom.pas
@@ -3022,7 +3022,13 @@ end;
 
   { write shorthand type }
   procedure wrttypc(var f: text; tp: stp; fl: integer);
-  const maxtrk = 4000;
+  const maxtrk = 20000; { type track capacity; also the error 227 threshold. A
+                          large record graph (e.g. a window control record that
+                          transitively expands a whole drawing type graph) can
+                          exceed a few thousand digest characters. The digest is
+                          emitted correctly regardless; this only bounds cycle
+                          tracking, so raising it cannot change behavior for any
+                          type that fit under the old limit. }
   var typtrk: array [1..maxtrk] of stp; cti: integer; err: boolean;
 
   procedure wrttypsub(tp: stp);

--- a/source/pint.pas
+++ b/source/pint.pas
@@ -363,7 +363,10 @@ const
       extsrc      = '.pas'; { extention for source file }
       maxwth      = 10;   { maximum number of watched addresses }
       maxana      = 10;   { maximum depth of analyzer traces }
-      maxsym      = 4000; { maximum length of symbol/module name }
+      maxsym      = 20000; { maximum length of symbol/module name. The name
+                             embeds the type digest, which can run to several
+                             thousand characters for a large record graph;
+                             matches pcom's maxtrk. }
       extvecmax   = 1024; { reserved external vector table slots }
 
 type


### PR DESCRIPTION
Fixes #592.

## Problem

`pcom` reported error 227 "Type too complex to track" for a module global whose type digest exceeded `maxtrk = 4000` characters (`source/pcom.pas`). It's a pure **capacity** check — the digest is emitted correctly and pgen/gcc consume it fine; a large record graph (the ICD CAD program's window-control record transitively expands the whole drawing type graph to ~4656 chars) just overran the tracking array.

## Change

- **`pcom.pas`**: `maxtrk` 4000 → 20000 (the type-track array capacity and the 227 threshold).
- **`pint.pas`**: `maxsym` 4000 → 20000 (symbol/module-name length, which embeds the digest) to match, so pint-mode runs resolve the external names.

`parser.pas` was mentioned in the issue but does not define `maxtrk` — the constant lives only in `pcom.pas`.

## Why it's safe

The digest itself is unchanged; `maxtrk` only bounds cycle tracking, so raising it **cannot** change behavior for any type that fit under the old limit. Memory impact is modest: `typtrk` becomes a 20000-pointer local (~160 KB stack); pint's two `symnam` locals become 20 KB each.

## Verification

- A large-digest module errored **227 with the old pcom** and **compiles clean with the new one**.
- **Byte-identical decks** for hello, iso7185pat, and pcom itself (old vs new pcom) — no behavior change for normal code.
- pgen regression (hello, iso7185pat) passes.

Source-only; the rebuilt pcom/pint products follow from a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)