### PR TITLE
network: buffer the connection through stdio_setvbuf, not glibc setvbuf

### DIFF
--- a/libs/source/network_support.c
+++ b/libs/source/network_support.c
@@ -49,9 +49,12 @@ extern void* psystem_libcwrfil(pfile f);
 #ifdef __MINGW32__
 #define stdio_fdopen(fd, mode) ((void*)fdopen((fd), (mode)))
 #define stdio_fileno(fp)       fileno((FILE*)(fp))
+#define stdio_setvbuf(fp, buf, mode, size) \
+    setvbuf((FILE*)(fp), (buf), (mode), (size))
 #else
 extern void* stdio_fdopen(int fd, const char* mode);
 extern int   stdio_fileno(void* fp);
+extern int   stdio_setvbuf(void* fp, char* buf, int mode, size_t size);
 #endif
 
 /* glibc FILE for a connection, indexed by its file descriptor, so the
@@ -77,7 +80,11 @@ static void bindnet(pfile infile, pfile outfile, FILE* gf)
        Line buffer the stream so a writeln reaches the socket at its newline
        without a close to flush it, while reads stay buffered. */
     af = stdio_fdopen(fd, "r+");
-    setvbuf((FILE*)af, NULL, _IOLBF, BUFSIZ);
+    /* af is an Ami-stdio FILE, so its buffering must be set through the Ami
+       stdio's setvbuf (stdio_setvbuf), not glibc's -- glibc's setvbuf would
+       dereference the Ami FILE as a glibc FILE and crash. On Windows there is
+       one stdio world, so stdio_setvbuf maps to the standard setvbuf. */
+    stdio_setvbuf(af, NULL, _IOLBF, BUFSIZ);
     psystem_libcatcfilset(infile, outfile, af);
 }
 


### PR DESCRIPTION
## Symptom

Native `network_test` segfaults right after the first test:
```
Network test vs. 0.4
addrnet localhost                        pass
Segmentation fault (core dumped)
```

## Cause

`bindnet` (`network_support.c`) reopens the connection's descriptor as an **Ami-stdio** file via `stdio_fdopen`, then set line buffering with the plain `setvbuf`. On linux that `setvbuf` links to **glibc's `_IO_setvbuf`**, which dereferences the Ami-stdio FILE as a glibc FILE → SIGSEGV. gdb confirmed: `af` is a valid Ami FILE (`0x8b1060`), `fd` valid (`3`), crash inside glibc `setvbuf`.

The Ami-stdio and glibc FILE structs are different worlds; the buffering call must match the FILE's world — exactly as `stdio_fdopen`/`stdio_fileno` already do for this same file.

## Fix

Use the Ami stdio's own **`stdio_setvbuf`** (declared next to the existing `stdio_fdopen`/`stdio_fileno` externs). On Windows there is a single stdio world, so `stdio_setvbuf` maps to the standard `setvbuf`.

## Verification

Native `bin/network_test` now runs to completion — **7 passes, 0 fails**:
```
addrnet localhost / TCP exchange in the clear / message exchange in the clear /
message exchange secured (DTLS) / maxmsg sane / relymsg sane / certnet raw certificate
```

The interpreter models (pint/pmach/cmach) route network through their externals, not this native `bindnet` path, which is why the regression did not surface it.

Source-only; rebuilt `network.a`/`network_test` products follow from a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)