### PR TITLE
pcom: don't segfault when max()'s argument is not a variable (fixes #599)

### DIFF
--- a/source/pcom.pas
+++ b/source/pcom.pas
@@ -6444,11 +6444,17 @@ end;
 
     procedure maxfunction;
       var lattr: attr; lvl, lmn, lmx: integer; lsp, lsp1: stp; lvalu: valu;
+          arrf: boolean;
     begin chkstd;
       if sy = lparent then insymbol else error(9);
       variable(fsys+[rparent,comma], false);
       lattr := gattr;
-      if (lattr.typtr <> nil) and (lattr.typtr^.form = arrays) then begin
+      { fixed array? guard the nil type separately -- Pascal does not
+        short-circuit 'and', so the form test must not run when typtr is nil
+        (e.g. the argument was not a variable) }
+      arrf := false;
+      if lattr.typtr <> nil then arrf := lattr.typtr^.form = arrays;
+      if arrf then begin
         { fixed array: max is the static upper bound (last index) at the level.
           The level, if given, must be a constant since the geometry is static. }
         lvl := 1;

--- a/source/pcom.pas
+++ b/source/pcom.pas
@@ -8332,7 +8332,7 @@ end;
 
     procedure fixeddeclaration;
       var lcp: ctp; lsp: stp; lsize: addrrange;
-          v: integer; d: boolean; dummy: stp;
+          v: integer; d: boolean; dummy: stp; contf: boolean;
     procedure fixeditem(fsys: setofsys; lsp: stp; size: integer; var v: integer; var d: boolean);
       var fvalu: valu; lsp1: stp; lcp: ctp; i, min, max: integer;
           test: boolean;
@@ -8467,8 +8467,11 @@ end;
           if fv.intval then begin
             if typ = charptr then write(prr, 'c c ', fv.ival:1)
             else if typ = boolptr then write(prr, 'c b ', fv.ival:1)
-            else if (typ <> nil) and (typ^.size = 1) then
-              write(prr, 'c x ', fv.ival:1)
+            else if typ <> nil then begin
+              { nil guarded separately: Pascal does not short-circuit 'and' }
+              if typ^.size = 1 then write(prr, 'c x ', fv.ival:1)
+              else write(prr, 'c i ', fv.ival:1)
+            end
             else write(prr, 'c i ', fv.ival:1)
           end else if fv.valp <> nil then begin
             if fv.valp^.cclass = reel then write(prr, 'c r ', fv.valp^.rval:23)
@@ -8563,7 +8566,11 @@ end;
         if sy = colon then insymbol else error(5);
         typ(fsys + [semicolon,relop] + typedels,lsp,lsize);
         if lcp <> nil then lcp^.idtype := lsp;
-        if (lcp <> nil) and (lsp <> nil) and (lsp^.form = arrayc) then
+        { container? guard the nil type separately -- Pascal does not
+          short-circuit 'and', so the form test must not run when lsp is nil }
+        contf := false;
+        if lcp <> nil then if lsp <> nil then contf := lsp^.form = arrayc;
+        if contf then
           { container: determine geometry from the initializer }
           fixedcontainer(lcp)
         else begin

--- a/source/pgen/independent.pas
+++ b/source/pgen/independent.pas
@@ -3479,9 +3479,13 @@ end;
 
 { emit variable/parameter DIE }
 procedure dwemitvar(sp: psymbol);
-var pc: dwparctl; tl, abbcode: integer;
+var pc: dwparctl; tl, abbcode: integer; hasdig: boolean;
 begin
-  if (sp^.digest <> nil) and (max(sp^.digest^) > 0) then begin
+  { nil guarded separately: Pascal does not short-circuit 'and', so the
+    digest length must not be taken when the digest is nil }
+  hasdig := false;
+  if sp^.digest <> nil then hasdig := max(sp^.digest^) > 0;
+  if hasdig then begin
     { parse digest to get/emit type, get label }
     dwsetpar(pc, sp^.digest);
     dwparsedigest(pc, tl);


### PR DESCRIPTION
## Root cause (not a back-end bug)

Issue #599 was reported as the AMD64 back end omitting label definitions (`undefined reference to cktpat.3`/`.214`, or a pgen "Label format error" with `-r`). The real cause is upstream: **pcom segfaults**, leaving a **truncated `.p6`** (exactly 96 KB, ending mid-instruction with no newline). The missing tail is the program main block — which is where labels 3 (program entry) and 214 (program `label 99`) are defined — so pgen sees references with no definitions, and on `-r` trips over the half-written last line.

The segfault is a classic **non-short-circuit nil-deref** in `maxfunction` (`source/pcom.pas`):

```pascal
if (lattr.typtr <> nil) and (lattr.typtr^.form = arrays) then
```

Pascal always evaluates both operands, so when the argument isn't a variable — e.g. `max(T)` where `T` is a **type name** — `variable()` leaves `gattr.typtr` nil and `lattr.typtr^.form` dereferences nil.

`cpg.pas` triggers it with `max(nodlab)` (and `nodlab[li]`), where `nodlab` is the array **type** and the local variable `w: nodlab` was intended — a typo in that program, but pcom must diagnose it, not crash.

## Fix

Compute the array test with a separate nil guard, matching the nested-if style the rest of `maxfunction` already uses:

```pascal
arrf := false;
if lattr.typtr <> nil then arrf := lattr.typtr^.form = arrays;
if arrf then begin ... end else begin ... end
```

## Verification

- `max(<type name>)` now reports **error 396 (identifier is the wrong kind)** instead of SIGSEGV.
- pcom **self-compiles** cleanly with the fix.
- On error, pcom deletes the output file, so no truncated `.p6` and no downstream pgen confusion.

Source-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)