### PR TITLE
pcom: refer() accepts a comma separated identifier list

### DIFF
--- a/source/pcom.pas
+++ b/source/pcom.pas
@@ -6423,15 +6423,20 @@ end;
     end;
 
     procedure referprocedure;
-    var lcp: ctp;
+    var lcp: ctp; test: boolean;
     begin chkstd;
-       if sy <> ident then begin
-          error(2); skip(fsys + [comma,rparent])
-       end else begin 
-          searchid([types,konst,vars,fixedt,field,func,proc],lcp);
-          lcp^.refer := true;
-          insymbol
-       end
+       { accept a comma separated list of identifiers }
+       repeat
+          if sy <> ident then begin
+             error(2); skip(fsys + [comma,rparent])
+          end else begin
+             searchid([types,konst,vars,fixedt,field,func,proc],lcp);
+             lcp^.refer := true;
+             insymbol
+          end;
+          test := sy <> comma;
+          if not test then insymbol
+       until test
     end;
 
     procedure seterrprocedure;


### PR DESCRIPTION
`refer(a, b)` previously failed with error 4 (`')' expected`) at the comma — `referprocedure` parsed exactly one identifier, even though its error-recovery skip set already included `comma` (the list form was evidently intended). Suppressing several unreferenced warnings took one `refer` call per identifier.

## Change

Wrap the identifier parse in a comma loop (the `readprocedure` pattern). Each identifier in the list gets `refer := true`.

## Verification

- `refer(a, b, c, p)` compiles and runs (vars and a procedure mixed).
- Single-argument `refer(a)` unchanged.
- Malformed list `refer(a, , b)` reports error 2 (identifier expected) and recovers.
- pcom self-compiles to a byte-identical fixed point.

Source-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)