### PR TITLE
pcom: add fbyte, pbyte and pabyte to the predeclared common types

### DIFF
--- a/source/pcom.pas
+++ b/source/pcom.pas
@@ -159,7 +159,7 @@ const
    maxsp      = 115;  { number of standard procedures/functions }
    maxins     = 131;  { maximum number of instructions }
    maxids     = 250;  { maximum characters in id string (basically, a full line) }
-   maxstd     = 84;   { number of standard identifiers }
+   maxstd     = 87;   { number of standard identifiers }
    maxres     = 68;   { number of reserved words }
    reslen     = 9;    { maximum length of reserved words }
    explen     = 32;   { length of exception names }
@@ -552,7 +552,8 @@ var
     boolptr,nilptr,textptr,
     exceptptr,stringptr,pstringptr,
     byteptr,vectorptr,matrixptr,
-    abyteptr,scharptr: stp;         (*pointers to entries of standard ids*)
+    abyteptr,scharptr,fbyteptr,
+    pbyteptr,pabyteptr: stp;        (*pointers to entries of standard ids*)
     utypptr,ucstptr,uvarptr,
     ufldptr,uprcptr,ufctptr,        (*pointers to entries for undeclared ids*)
     fwptr: ctp;                     (*head of chain of forw decl type ids*)
@@ -11122,6 +11123,7 @@ end;
     na[76] := 'string   '; na[77] := 'pstring  '; na[78] := 'byte     ';
     na[79] := 'vector   '; na[80] := 'matrix   '; na[81] := 'abyte    ';
     na[82] := 'schar    '; na[83] := 'refer    '; na[84] := 'seterr   ';
+    na[85] := 'fbyte    '; na[86] := 'pbyte    '; na[87] := 'pabyte   ';
 
   end (*stdnames*) ;
 
@@ -11194,6 +11196,18 @@ end;
     with scharptr^ do
       begin form := power; size := setsize; packing := false; elset := charptr;
             matchpack := true end;
+    new(fbyteptr,files); pshstc(fbyteptr);                    (*file of byte*)
+    with fbyteptr^ do
+      begin form := files; filtype := byteptr; size := filesize+1;
+            packing := false end;
+    new(pbyteptr,pointer); pshstc(pbyteptr);                  (*byte pointer*)
+    with pbyteptr^ do
+      begin form := pointer; size := ptrsize; packing := false;
+            eltype := byteptr end;
+    new(pabyteptr,pointer); pshstc(pabyteptr);              (*byte array pointer*)
+    with pabyteptr^ do
+      begin form := pointer; size := ptrsize; packing := false;
+            eltype := abyteptr end;
   end (*enterstdtypes*) ;
 
   procedure entstdnames;
@@ -11290,6 +11304,9 @@ end;
     entstdtyp(80, matrixptr);                                 (*matrix*)
     entstdtyp(81, abyteptr);                                  (*array of bytes*)
     entstdtyp(82, scharptr);                                  (*set of char*)
+    entstdtyp(85, fbyteptr);                                  (*file of byte*)
+    entstdtyp(86, pbyteptr);                                  (*pointer to byte*)
+    entstdtyp(87, pabyteptr);                            (*pointer to abyte*)
 
     cp1 := nil;
     for i := 1 to 2 do


### PR DESCRIPTION
Adds three predeclared types alongside the existing common types (`string`, `pstring`, `byte`, `abyte`, `vector`, `matrix`, `schar`):

```pascal
fbyte  = file of byte;   { untyped byte stream }
pbyte  = ^byte;
pabyte = ^abyte;         { pointer to container byte array }
```

`fbyte` follows the `text` pattern (`files` form, `filtype` byte, size `filesize+1` — matching what a user-declared `file of byte` gets); the pointers follow the `pstring` pattern. `schar` (`set of char`) was requested too but already exists — unchanged.

Mechanics: `maxstd` 84→87, three new stp globals, three type records in `enterstdtypes`, names `na[85..87]`, and `entstdtyp` entries.

## Verification

- `fbyte`: `rewrite`/`write`/`reset`/`read` round-trips bytes.
- `pbyte`: `new`, deref assignment, `dispose`.
- `pabyte`: `new(pa, 10)`, indexing, `max(pa^)` length — container semantics intact.
- User declarations still shadow the predeclared names (`type fbyte = integer;` compiles).
- pcom self-compiles to a byte-identical fixed point.

Source-only. The Pascaline spec's §6.38 Common Types section will need matching entries when docs are next updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)