### PR TITLE
pcom: patch fvalu after error 134 in constant set elements

### DIFF
--- a/source/pcom.pas
+++ b/source/pcom.pas
@@ -4385,12 +4385,14 @@ end;
           new(lvp,pset); pshcst(lvp); lvp^.cclass := pset; lvp^.pval := [];
           if sy <> rbrack then repeat
             constexpr(fsys+[rbrack,comma,range], fsp, fvalu);
-            if not fvalu.intval then error(134);
+            if not fvalu.intval then
+              begin error(134); fvalu.intval := true; fvalu.ival := setlow end;
             if sy = range then begin
               insymbol; lv := fvalu;
               constexpr(fsys+[rbrack,comma], fsp, fvalu);
-              if not fvalu.intval then error(134);
-              if (lv.ival < setlow) or (lv.ival > sethigh) or 
+              if not fvalu.intval then
+                begin error(134); fvalu.intval := true; fvalu.ival := setlow end;
+              if (lv.ival < setlow) or (lv.ival > sethigh) or
                  (fvalu.ival < setlow) or (fvalu.ival > sethigh) then error(291)
               else for i := lv.ival to fvalu.ival do lvp^.pval := lvp^.pval+[i]
             end else begin


### PR DESCRIPTION
## Summary

A non-ordinal constant (e.g. a string) used as a constant set element or range bound raised error 134 but then fell through into the set-building logic and read `fvalu.ival` while the `valp` variant was active, killing the compile with a runtime variant check instead of producing an error listing:

```pascal
const bad = ['ab'..'cd'];
```
```
*** Runtime error: pcom:4395:Variant not active
```

Both check sites in the constant set parser (the range and single-element paths) now patch `fvalu` to a safe integer (`setlow`) after reporting error 134, matching the recovery convention used elsewhere in pcom (report, patch, continue). `setlow` keeps the downstream setlow/sethigh range checks quiet so the source error is reported exactly once.

Found in the wild: a UTF-8-mangled ISO 8859-1 source file turned single-char set range bounds into multi-byte string constants, and pcom crashed instead of listing the error.

## Testing

- Repro above plus `['x', 'yz']` now list error 134 with carets and complete normally
- Full `bin/build` passes
- Recompiled the pascomp parser modules against the rebuilt pcom: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9os8NdnEDP2Meb9ztCdfe