### PR TITLE
services: remove stale seterr external declaration

### DIFF
--- a/libs/services.pas
+++ b/libs/services.pas
@@ -138,7 +138,6 @@ procedure setoper(view fn: string; p: permset); external;
 overload procedure setoper(fn: pstring; p: permset); external;
 procedure resoper(view fn: string; p: permset); external;
 overload procedure resoper(fn: pstring; p: permset); external;
-procedure seterr(e: integer); external;
 procedure makpth(view fn: string); external;
 overload procedure makpth(fn: pstring); external;
 procedure rempth(view fn: string); external;


### PR DESCRIPTION
## Summary

`seterr` moved to psystem and became pcom standard procedure 84 (csp 33) because it accesses runtime internals not available to the C services layer. The leftover `procedure seterr(e: integer); external;` in the services header (`libs/services.pas:141`) shadows the standard procedure for any program that `uses services`, capturing the call as `services.seterr` — which no library implements:

```
/usr/bin/ld: undefined reference to 'services.seterr$p_i'
```

Removing the declaration lets calls bind to the standard procedure.

## Testing

- `program setest; begin seterr(5) end.` builds and exits with code 5
- A program that `uses services` and calls `seterr` (the pascomp parser's error handler) previously failed at link exactly as above; with the declaration removed it links and the exit code reaches the shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9os8NdnEDP2Meb9ztCdfe