### PR TITLE
pcom: keep module attribution of exception vars in try on-clauses

### DIFF
--- a/source/pcom.pas
+++ b/source/pcom.pas
@@ -10269,13 +10269,15 @@ end;
             if sy = ident then begin
               searchid([vars],lcp);
               with lcp^, lattr do
-                begin typtr := idtype; kind := varbl; packing := false;
+                begin symptr := lcp; typtr := idtype; kind := varbl;
+                  packing := false;
                   if threat or (forcnt > 0) then error(195); forcnt := forcnt+1;
                   if part = ptview then error(290);
                   if vkind = actual then
                     begin access := drct; vlevel := vlev;
                       if vlev <> level then error(183);
-                      dplmt := vaddr
+                      { don't offset far }
+                      if chkext(lcp) then dplmt := 0 else dplmt := vaddr
                     end
                   else begin error(155); typtr := nil end
                 end;


### PR DESCRIPTION
## Summary

Exceptions match by treating the exception variable's address as a unique number: throw records it, and each `on` clause compares against it. The on-clause in `trystatement` builds its variable access by hand and drops the external attribution the normal variable path applies — no `symptr`, and `dplmt := vaddr` unconditionally. For an exception variable imported from a module, the handler compiles to a bare offset into the catching unit's own global block with no relocation emitted (`nm` shows no reference to the module's symbol), so the compare vector never equals the thrower's address and every cross-module throw falls to the master handler.

17-line repro (module exports `parabort: exception` and throws it; program catches with `on parabort except`):

```
before
*** Runtime error: exprog:13:Master exception
```

The fix applies the same pattern as the for-statement control-variable site: set `symptr` and use the `chkext` offset rule so loadaddress emits the module-qualified symbol.

## Testing

- Repro above now prints `before` / `cleanup` and exits 0; `nm` on the program object shows the proper `U exmod.parabort` reference
- Single-unit exceptions unaffected (native and pint)
- Full `bin/build` passes
- Real-world case: the pascomp parser's module-exported abort exception now lands in the program's handler, runs cleanup, and returns its `seterr` exit code to the shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9os8NdnEDP2Meb9ztCdfe